### PR TITLE
Add meta descriptions to pages

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -30,7 +30,7 @@
 				"@type": "WebSite",
 				"name": "teeline.online",
 				"url": "https://teeline.online/",
-				"description": "A free, interactice learning resource for studying Teeline shorthand.",
+				"description": "A free, interactive learning resource for studying Teeline shorthand.",
 				"creator": {
 					"@type": "Person",
 					"name": "Frederick O'Brien",

--- a/src/learn-content/connecting-letters.svx
+++ b/src/learn-content/connecting-letters.svx
@@ -1,5 +1,6 @@
 ---
 title: Connecting letters
+description: How and why to join letters together in Teeline shorthand
 ---
 
 <script>

--- a/src/learn-content/disemvowelment.svx
+++ b/src/learn-content/disemvowelment.svx
@@ -1,5 +1,6 @@
 ---
 title: Disemvowelment
+description: The glorious gory art of removing superflous letters from words in Teeline shorthand
 ---
 
 <script>

--- a/src/learn-content/introduction.svx
+++ b/src/learn-content/introduction.svx
@@ -1,5 +1,6 @@
 ---
 title: Introduction
+description: Getting started with Teeline shorthand
 ---
 
 Shorthand is a way of writing lots of words really quickly. Teeline is a type of shorthand and the recommended system of the [National Council for the Training of Journalists](https://www.nctj.com/). Trainees need to be able to transcribe at 60 words per minute (wpm) to get their NCTJ diploma, while 100 is needed to achieve the 'gold standard'. Some can write as fast as 120 wpm and beyond.

--- a/src/learn-content/letter-positioning-and-hierarchy.svx
+++ b/src/learn-content/letter-positioning-and-hierarchy.svx
@@ -1,5 +1,6 @@
 ---
 title: Letter positioning and hierarchy
+description: Exploring the quirks of how letter placement affects meaning in Teeline shorthand
 ---
 
 <script>

--- a/src/learn-content/silent-and-double-letters.svx
+++ b/src/learn-content/silent-and-double-letters.svx
@@ -1,5 +1,6 @@
 ---
 title: Silent and double letters
+description: The nitty gritty of removing unheard letters from words in Teeline shorthand
 ---
 
 <script>

--- a/src/learn-content/special-outlines.svx
+++ b/src/learn-content/special-outlines.svx
@@ -1,5 +1,6 @@
 ---
 title: Special outlines
+descriptions: When Teeline shorthand needs its own shorthand, look no further than special outlines
 ---
 
 <script>

--- a/src/learn-content/the-alphabet.svx
+++ b/src/learn-content/the-alphabet.svx
@@ -1,5 +1,6 @@
 ---
 title: The alphabet
+description: Even shorthand begins with learning your ABCs. This is an intro to the Teeline alphabet
 ---
 
 Teeline is spelling-based rather than phonetic and as such has a typical A-to-Z alphabet. You can view this below, and an interactive view is availabe on [the outlines page](/outlines).

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
 
 <svelte:head>
 	<meta charset="UTF-8" />
+
 	<meta name="keywords" content="Shorthand, Teeline, Journalism" />
 
 	<meta name="twitter:card" content="summary_large_image" />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 	<title>teeline.online</title>
 	<meta
 		name="description"
-		content="A free learning resource for Teeline shorthand. Study theory, browse hundreds of outlines, and revise with digital flashcards as you work towards 100wpm."
+		content="A free, interactive learning resource for Teeline shorthand. Study theory, browse outlines, and revise with flash cards to get to 100wpm and beyond."
 	/>
 </svelte:head>
 

--- a/src/routes/learn/+page.svelte
+++ b/src/routes/learn/+page.svelte
@@ -13,6 +13,10 @@
 
 <svelte:head>
 	<title>Learn | teeline.online</title>
+	<meta
+		name="description"
+		content="Explore the theory and execution of Teeline shorthand - from core principles to special outlines. Be sure to play around with the Disemvoweler 9000!"
+	/>
 </svelte:head>
 
 <div class="copy-container">

--- a/src/routes/learn/[slug]/+page.js
+++ b/src/routes/learn/[slug]/+page.js
@@ -1,10 +1,12 @@
 export async function load({ params }) {
     const post = await import(`../../../learn-content/${params.slug}.svx`)
     const title = post.metadata.title
+    const description = post.metadata.description
     const content = post.default
 
     return {
         title,
+        description,
         content
     }
 }

--- a/src/routes/learn/[slug]/+page.svelte
+++ b/src/routes/learn/[slug]/+page.svelte
@@ -4,6 +4,7 @@
 
 <svelte:head>
 	<title>{data.title} | Learn | teeline.online</title>
+	<meta name="description" content={data.description} />
 </svelte:head>
 
 <div class="copy-container">

--- a/src/routes/outlines/+page.svelte
+++ b/src/routes/outlines/+page.svelte
@@ -35,6 +35,10 @@
 
 <svelte:head>
 	<title>Outlines | teeline.online</title>
+	<meta
+		name="description"
+		content="Browse and search an interactive library of hundreds of animated Teeline shorthand outlines, ranging from the alphabet to special abbreviations."
+	/>
 </svelte:head>
 
 <div class="filters-container">

--- a/src/routes/revise/+page.svelte
+++ b/src/routes/revise/+page.svelte
@@ -24,6 +24,10 @@
 
 <svelte:head>
 	<title>Revise | teeline.online</title>
+	<meta
+		name="description"
+		content="Work your way through hundreds of virtual flash cards to sear Teeline shorthand outlines into your brain and get your speed closer to the sacred 100wpm."
+	/>
 </svelte:head>
 
 <svelte:window on:keydown={handleKeydown} />


### PR DESCRIPTION
Rookie error not to have in the first place, but better late than never. This PR adds meta descriptions to all teeline.online pages. All are below 155 characters so hopefully a search engine friendly length.