### PR TITLE
Add flashcard toggle to /revise page

### DIFF
--- a/src/lib/cards/OutlineCardFlipping.svelte
+++ b/src/lib/cards/OutlineCardFlipping.svelte
@@ -3,17 +3,30 @@
 	import { prettify } from '../../scripts/helpers';
 
 	export let outlineObject;
+	export let outlineFirst;
 </script>
 
 <div class="flip-card">
 	<div class="flip-card-inner">
 		<div class="flip-card-front">
 			<div class="svg-container">
-				<OutlineSvg {outlineObject} />
+				{#if outlineFirst}
+					<div class="svg-container">
+						<OutlineSvg {outlineObject} />
+					</div>
+				{:else}
+					<div>{prettify(outlineObject.specialOutlineMeanings)}</div>
+				{/if}
 			</div>
 		</div>
 		<div class="flip-card-back">
-			<div>{prettify(outlineObject.specialOutlineMeanings)}</div>
+			<div class="svg-container">
+				{#if outlineFirst}
+					<div>{prettify(outlineObject.specialOutlineMeanings)}</div>
+				{:else}
+					<OutlineSvg {outlineObject} />
+				{/if}
+			</div>
 		</div>
 	</div>
 </div>

--- a/src/lib/toggle.svelte
+++ b/src/lib/toggle.svelte
@@ -1,0 +1,80 @@
+<script>
+	export let toggleLabel;
+	export let toggleFunction;
+</script>
+
+<div class="filter-label">{toggleLabel}</div>
+<label class="switch">
+	<input type="checkbox" on:click={toggleFunction} />
+	<span class="slider round" />
+</label>
+
+<style>
+	.filter-label {
+		margin-right: 0.5rem;
+		display: inline-block;
+		font-size: 1.8rem;
+	}
+	/* The switch - the box around the slider */
+	.switch {
+		position: relative;
+		display: inline-block;
+		width: 60px;
+		height: 34px;
+	}
+
+	/* Hide default HTML checkbox */
+	.switch input {
+		opacity: 0;
+		width: 0;
+		height: 0;
+	}
+
+	/* The slider */
+	.slider {
+		position: absolute;
+		cursor: pointer;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		background-color: #ccc;
+		-webkit-transition: 0.4s;
+		transition: 0.4s;
+	}
+
+	.slider:before {
+		position: absolute;
+		content: '';
+		height: 26px;
+		width: 26px;
+		left: 4px;
+		bottom: 4px;
+		background-color: white;
+		-webkit-transition: 0.4s;
+		transition: 0.4s;
+	}
+
+	input:checked + .slider {
+		background-color: black;
+	}
+
+	input:focus + .slider {
+		box-shadow: 0 0 1px black;
+	}
+
+	input:checked + .slider:before {
+		-webkit-transform: translateX(26px);
+		-ms-transform: translateX(26px);
+		transform: translateX(26px);
+	}
+
+	/* Rounded sliders */
+	.slider.round {
+		border-radius: 34px;
+	}
+
+	.slider.round:before {
+		border-radius: 50%;
+	}
+</style>

--- a/src/routes/outlines/+page.svelte
+++ b/src/routes/outlines/+page.svelte
@@ -1,5 +1,6 @@
 <script>
 	import OutlineCardAnimated from '$lib/cards/OutlineCardAnimated.svelte';
+	import Toggle from '../../lib/toggle.svelte';
 	import { outlines } from '../../data/outlines/outlines';
 	import { sortAlphabetically } from '../../scripts/helpers';
 
@@ -15,14 +16,14 @@
 		lowerCaseAlphabet.some((letter) => outline.specialOutlineMeanings.includes(letter))
 	);
 
-	function toggleAlphabetFilter() {
+	const toggleAlphabetFilter = () => {
 		displayedOutlines = alphabetToggleOn ? outlines : alphabetOutlines;
 		alphabetToggleOn = alphabetToggleOn ? false : true;
 
 		searchTerm = null;
-	}
+	};
 
-	function filterOutlines(outlines, searchTerm) {
+	const filterOutlines = (outlines, searchTerm) => {
 		if (alphabetToggleOn) {
 			displayedOutlines = alphabetOutlines.filter((outline) =>
 				outline.specialOutlineMeanings.join('').includes(searchTerm)
@@ -32,7 +33,7 @@
 				outline.specialOutlineMeanings.join('').includes(searchTerm)
 			);
 		}
-	}
+	};
 </script>
 
 <svelte:head>
@@ -44,11 +45,7 @@
 </svelte:head>
 
 <div class="filters-container">
-	<div class="filter-label">Only show alphabet</div>
-	<label class="switch">
-		<input type="checkbox" on:click={toggleAlphabetFilter} />
-		<span class="slider round" />
-	</label>
+	<Toggle toggleLabel={`Only show alphabet`} toggleFunction={toggleAlphabetFilter} />
 	<input
 		class="search-input"
 		placeholder="Search for outlines..."
@@ -80,72 +77,5 @@
 	.filters-container {
 		margin: 0 auto 2rem auto;
 		width: max-content;
-	}
-	.filter-label {
-		margin-right: 0.5rem;
-		display: inline-block;
-		font-size: 1.8rem;
-	}
-	/* The switch - the box around the slider */
-	.switch {
-		position: relative;
-		display: inline-block;
-		width: 60px;
-		height: 34px;
-	}
-
-	/* Hide default HTML checkbox */
-	.switch input {
-		opacity: 0;
-		width: 0;
-		height: 0;
-	}
-
-	/* The slider */
-	.slider {
-		position: absolute;
-		cursor: pointer;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		background-color: #ccc;
-		-webkit-transition: 0.4s;
-		transition: 0.4s;
-	}
-
-	.slider:before {
-		position: absolute;
-		content: '';
-		height: 26px;
-		width: 26px;
-		left: 4px;
-		bottom: 4px;
-		background-color: white;
-		-webkit-transition: 0.4s;
-		transition: 0.4s;
-	}
-
-	input:checked + .slider {
-		background-color: black;
-	}
-
-	input:focus + .slider {
-		box-shadow: 0 0 1px black;
-	}
-
-	input:checked + .slider:before {
-		-webkit-transform: translateX(26px);
-		-ms-transform: translateX(26px);
-		transform: translateX(26px);
-	}
-
-	/* Rounded sliders */
-	.slider.round {
-		border-radius: 34px;
-	}
-
-	.slider.round:before {
-		border-radius: 50%;
 	}
 </style>

--- a/src/routes/revise/+page.svelte
+++ b/src/routes/revise/+page.svelte
@@ -49,7 +49,7 @@
 	</div>
 
 	<div class="button-container">
-		<button class="button" on:click={changeOutline}>Next card</button>
+		<button class="button" on:click={changeOutline}>Next card...</button>
 	</div>
 </div>
 

--- a/src/routes/revise/+page.svelte
+++ b/src/routes/revise/+page.svelte
@@ -1,25 +1,31 @@
 <script>
 	import { outlines } from '../../data/outlines/outlines';
 	import FlippingOutlineCard from '../../lib/cards/OutlineCardFlipping.svelte';
+	import Toggle from '../../lib/toggle.svelte';
 	import { shuffle } from '../../scripts/helpers';
 
 	const shuffledOutlines = shuffle(outlines);
 
 	let counter = 0;
 	let outlineObject = shuffledOutlines[counter];
+	let outlineFirst = false;
 
-	function changeOutline() {
+	const changeOutline = () => {
 		if (counter === outlines.length - 1) counter = 0;
 		else counter++;
 		console.log(counter);
 		outlineObject = shuffledOutlines[counter];
-	}
+	};
 
-	function handleKeydown(event) {
+	const handleKeydown = (event) => {
 		if (event.keyCode === 32) {
 			changeOutline();
 		}
-	}
+	};
+
+	const toggleCardOrientation = () => {
+		outlineFirst = !outlineFirst;
+	};
 </script>
 
 <svelte:head>
@@ -33,14 +39,17 @@
 <svelte:window on:keydown={handleKeydown} />
 
 <div class="content">
-	<p>Hover/tap to see what the outline stands for</p>
+	<div class="info-container">
+		<p>Hover over / tap on the flash card to see what it stands for</p>
+		<Toggle toggleLabel={`Show outlines first`} toggleFunction={toggleCardOrientation} />
+	</div>
 
 	<div class="flipcard-container">
-		<FlippingOutlineCard {outlineObject} />
+		<FlippingOutlineCard {outlineObject} {outlineFirst} />
 	</div>
 
 	<div class="button-container">
-		<button class="button" on:click={changeOutline}>New outline</button>
+		<button class="button" on:click={changeOutline}>Next card</button>
 	</div>
 </div>
 
@@ -49,7 +58,7 @@
 		padding: 20px 0;
 	}
 
-	p {
+	.info-container {
 		text-align: center;
 	}
 


### PR DESCRIPTION
As suggested by a user, this adjusts the revision page to allow people to choose which side of the flashcards they see first.

![image](https://user-images.githubusercontent.com/11380557/233780945-131da118-b510-4c48-aa2a-6cd5ab685a0e.png)

Small change but makes a lot of sense - effectively doubles the page's usefulness. Was also a nice excuse to extract the toggle (now used on both /outlines and /revise) into its own component.