### PR TITLE
Update `vite` to 4.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"vite": "^4.3.2"
 			},
 			"devDependencies": {
-				"@sveltejs/adapter-netlify": "^1.0.0-next.51",
+				"@sveltejs/adapter-netlify": "^2.0.6",
 				"@sveltejs/kit": "1.15.8",
 				"@tsconfig/svelte": "^4.0.1",
 				"@typescript-eslint/eslint-plugin": "^5.10.1",
@@ -30,9 +30,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.11.tgz",
-			"integrity": "sha512-PzMcQLazLBkwDEkrNPi9AbjFt6+3I7HKbiYF2XtWQ7wItrHvEOeO3T8Am434zAozWtVP7lrTue1bEfc2nYWeCA==",
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
+			"integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
 			"cpu": [
 				"arm"
 			],
@@ -181,9 +181,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.11.tgz",
-			"integrity": "sha512-geWp637tUhNmhL3Xgy4Bj703yXB9dqiLJe05lCUfjSFDrQf9C/8pArusyPUbUbPwlC/EAUjBw32sxuIl/11dZw==",
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
+			"integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
 			"cpu": [
 				"loong64"
 			],
@@ -523,14 +523,17 @@
 			"dev": true
 		},
 		"node_modules/@sveltejs/adapter-netlify": {
-			"version": "1.0.0-next.81",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-1.0.0-next.81.tgz",
-			"integrity": "sha512-jWZHw2uqUMJk8lFPzRm0xxmBZoDc430tbeCU9EtYhG+ypze2B6pJAlNTtcN3/J7wapHq19TgEK5oNt4LqORfNg==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-2.0.6.tgz",
+			"integrity": "sha512-9guxI9jG/v/JTr/I1E1YGKppKWRyvs60VuhPJcGBrj2MfoBxR40vhxkrWPFcNJoAdyQUSjqxbg7sZLA4WbNfgA==",
 			"dev": true,
 			"dependencies": {
 				"@iarna/toml": "^2.2.5",
-				"esbuild": "^0.15.7",
-				"set-cookie-parser": "^2.4.8"
+				"esbuild": "^0.16.3",
+				"set-cookie-parser": "^2.5.1"
+			},
+			"peerDependencies": {
+				"@sveltejs/kit": "^1.5.0"
 			}
 		},
 		"node_modules/@sveltejs/kit": {
@@ -1135,9 +1138,9 @@
 			"dev": true
 		},
 		"node_modules/esbuild": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.11.tgz",
-			"integrity": "sha512-OgHGuhlfZ//mToxjte1D5iiiQgWfJ2GByVMwEC/IuoXsBGkuyK1+KrjYu0laSpnN/L1UmLUCv0s25vObdc1bVg==",
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
+			"integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -1147,50 +1150,34 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.15.11",
-				"@esbuild/linux-loong64": "0.15.11",
-				"esbuild-android-64": "0.15.11",
-				"esbuild-android-arm64": "0.15.11",
-				"esbuild-darwin-64": "0.15.11",
-				"esbuild-darwin-arm64": "0.15.11",
-				"esbuild-freebsd-64": "0.15.11",
-				"esbuild-freebsd-arm64": "0.15.11",
-				"esbuild-linux-32": "0.15.11",
-				"esbuild-linux-64": "0.15.11",
-				"esbuild-linux-arm": "0.15.11",
-				"esbuild-linux-arm64": "0.15.11",
-				"esbuild-linux-mips64le": "0.15.11",
-				"esbuild-linux-ppc64le": "0.15.11",
-				"esbuild-linux-riscv64": "0.15.11",
-				"esbuild-linux-s390x": "0.15.11",
-				"esbuild-netbsd-64": "0.15.11",
-				"esbuild-openbsd-64": "0.15.11",
-				"esbuild-sunos-64": "0.15.11",
-				"esbuild-windows-32": "0.15.11",
-				"esbuild-windows-64": "0.15.11",
-				"esbuild-windows-arm64": "0.15.11"
+				"@esbuild/android-arm": "0.16.17",
+				"@esbuild/android-arm64": "0.16.17",
+				"@esbuild/android-x64": "0.16.17",
+				"@esbuild/darwin-arm64": "0.16.17",
+				"@esbuild/darwin-x64": "0.16.17",
+				"@esbuild/freebsd-arm64": "0.16.17",
+				"@esbuild/freebsd-x64": "0.16.17",
+				"@esbuild/linux-arm": "0.16.17",
+				"@esbuild/linux-arm64": "0.16.17",
+				"@esbuild/linux-ia32": "0.16.17",
+				"@esbuild/linux-loong64": "0.16.17",
+				"@esbuild/linux-mips64el": "0.16.17",
+				"@esbuild/linux-ppc64": "0.16.17",
+				"@esbuild/linux-riscv64": "0.16.17",
+				"@esbuild/linux-s390x": "0.16.17",
+				"@esbuild/linux-x64": "0.16.17",
+				"@esbuild/netbsd-x64": "0.16.17",
+				"@esbuild/openbsd-x64": "0.16.17",
+				"@esbuild/sunos-x64": "0.16.17",
+				"@esbuild/win32-arm64": "0.16.17",
+				"@esbuild/win32-ia32": "0.16.17",
+				"@esbuild/win32-x64": "0.16.17"
 			}
 		},
-		"node_modules/esbuild-android-64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.11.tgz",
-			"integrity": "sha512-rrwoXEiuI1kaw4k475NJpexs8GfJqQUKcD08VR8sKHmuW9RUuTR2VxcupVvHdiGh9ihxL9m3lpqB1kju92Ialw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-android-arm64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.11.tgz",
-			"integrity": "sha512-/hDubOg7BHOhUUsT8KUIU7GfZm5bihqssvqK5PfO4apag7YuObZRZSzViyEKcFn2tPeHx7RKbSBXvAopSHDZJQ==",
+		"node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
+			"integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1203,26 +1190,26 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild-darwin-64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.11.tgz",
-			"integrity": "sha512-1DqHD0ms3AhiwkKnjRUzmiW7JnaJJr5FKrPiR7xuyMwnjDqvNWDdMq4rKSD9OC0piFNK6n0LghsglNMe2MwJtA==",
+		"node_modules/esbuild/node_modules/@esbuild/android-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
+			"integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
 			"optional": true,
 			"os": [
-				"darwin"
+				"android"
 			],
 			"engines": {
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild-darwin-arm64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.11.tgz",
-			"integrity": "sha512-OMzhxSbS0lwwrW40HHjRCeVIJTURdXFA8c3GU30MlHKuPCcvWNUIKVucVBtNpJySXmbkQMDJdJNrXzNDyvoqvQ==",
+		"node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
+			"integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1235,26 +1222,26 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild-freebsd-64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.11.tgz",
-			"integrity": "sha512-8dKP26r0/Qyez8nTCwpq60QbuYKOeBygdgOAWGCRalunyeqWRoSZj9TQjPDnTTI9joxd3QYw3UhVZTKxO9QdRg==",
+		"node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
+			"integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
 			"optional": true,
 			"os": [
-				"freebsd"
+				"darwin"
 			],
 			"engines": {
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild-freebsd-arm64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.11.tgz",
-			"integrity": "sha512-aSGiODiukLGGnSg/O9+cGO2QxEacrdCtCawehkWYTt5VX1ni2b9KoxpHCT9h9Y6wGqNHmXFnB47RRJ8BIqZgmQ==",
+		"node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
+			"integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1267,42 +1254,26 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild-linux-32": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.11.tgz",
-			"integrity": "sha512-lsrAfdyJBGx+6aHIQmgqUonEzKYeBnyfJPkT6N2dOf1RoXYYV1BkWB6G02tjsrz1d5wZzaTc3cF+TKmuTo/ZwA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-linux-64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.11.tgz",
-			"integrity": "sha512-Y2Rh+PcyVhQqXKBTacPCltINN3uIw2xC+dsvLANJ1SpK5NJUtxv8+rqWpjmBgaNWKQT1/uGpMmA9olALy9PLVA==",
+		"node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
+			"integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
 			"optional": true,
 			"os": [
-				"linux"
+				"freebsd"
 			],
 			"engines": {
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild-linux-arm": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.11.tgz",
-			"integrity": "sha512-TJllTVk5aSyqPFvvcHTvf6Wu1ZKhWpJ/qNmZO8LL/XeB+LXCclm7HQHNEIz6MT7IX8PmlC1BZYrOiw2sXSB95A==",
+		"node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
+			"integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1315,10 +1286,10 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild-linux-arm64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.11.tgz",
-			"integrity": "sha512-uhcXiTwTmD4OpxJu3xC5TzAAw6Wzf9O1XGWL448EE9bqGjgV1j+oK3lIHAfsHnuIn8K4nDW8yjX0Sv5S++oRuw==",
+		"node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
+			"integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
 			"cpu": [
 				"arm64"
 			],
@@ -1331,10 +1302,26 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild-linux-mips64le": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.11.tgz",
-			"integrity": "sha512-WD61y/R1M4BLe4gxXRypoQ0Ci+Vjf714QYzcPNkiYv5I8K8WDz2ZR8Bm6cqKxd6rD+e/rZgPDbhQ9PCf7TMHmA==",
+		"node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
+			"integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
+			"integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -1347,10 +1334,10 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild-linux-ppc64le": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.11.tgz",
-			"integrity": "sha512-JVleZS9oPVLTlBhPTWgOwxFWU/wMUdlBwTbGA4GF8c38sLbS13cupj+C8bLq929jU7EMWry4SaL+tKGIaTlqKg==",
+		"node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
+			"integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1363,10 +1350,10 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild-linux-riscv64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.11.tgz",
-			"integrity": "sha512-9aLIalZ2HFHIOZpmVU11sEAS9F8TnHw49daEjcgMpBXHFF57VuT9f9/9LKJhw781Gda0P9jDkuCWJ0tFbErvJw==",
+		"node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
+			"integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1379,10 +1366,10 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild-linux-s390x": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.11.tgz",
-			"integrity": "sha512-sZHtiXXOKsLI3XGBGoYO4qKBzJlb8xNsWmvFiwFMHFzA4AXgDP1KDp7Dawe9C2pavTRBDvl+Ok4n/DHQ59oaTg==",
+		"node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
+			"integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
 			"cpu": [
 				"s390x"
 			],
@@ -1395,10 +1382,26 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild-netbsd-64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.11.tgz",
-			"integrity": "sha512-hUC9yN06K9sg7ju4Vgu9ChAPdsEgtcrcLfyNT5IKwKyfpLvKUwCMZSdF+gRD3WpyZelgTQfJ+pDx5XFbXTlB0A==",
+		"node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
+			"integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
+			"integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
 			"cpu": [
 				"x64"
 			],
@@ -1411,10 +1414,10 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild-openbsd-64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.11.tgz",
-			"integrity": "sha512-0bBo9SQR4t66Wd91LGMAqmWorzO0TTzVjYiifwoFtel8luFeXuPThQnEm5ztN4g0fnvcp7AnUPPzS/Depf17wQ==",
+		"node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
+			"integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
 			"cpu": [
 				"x64"
 			],
@@ -1427,10 +1430,10 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild-sunos-64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.11.tgz",
-			"integrity": "sha512-EuBdTGlsMTjEl1sQnBX2jfygy7iR6CKfvOzi+gEOfhDqbHXsmY1dcpbVtcwHAg9/2yUZSfMJHMAgf1z8M4yyyw==",
+		"node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
+			"integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
 			"cpu": [
 				"x64"
 			],
@@ -1443,10 +1446,26 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild-windows-32": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.11.tgz",
-			"integrity": "sha512-O0/Wo1Wk6dc0rZSxkvGpmTNIycEznHmkObTFz2VHBhjPsO4ZpCgfGxNkCpz4AdAIeMczpTXt/8d5vdJNKEGC+Q==",
+		"node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
+			"integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
+			"integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
 			"cpu": [
 				"ia32"
 			],
@@ -1459,28 +1478,12 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/esbuild-windows-64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.11.tgz",
-			"integrity": "sha512-x977Q4HhNjnHx00b4XLAnTtj5vfbdEvkxaQwC1Zh5AN8g5EX+izgZ6e5QgqJgpzyRNJqh4hkgIJF1pyy1be0mQ==",
+		"node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
+			"integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
 			"cpu": [
 				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/esbuild-windows-arm64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.11.tgz",
-			"integrity": "sha512-VwUHFACuBahrvntdcMKZteUZ9HaYrBRODoKe4tIWxguQRvvYoYb7iu5LrcRS/FQx8KPZNaa72zuqwVtHeXsITw==",
-			"cpu": [
-				"arm64"
 			],
 			"dev": true,
 			"optional": true,
@@ -3412,9 +3415,9 @@
 	},
 	"dependencies": {
 		"@esbuild/android-arm": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.11.tgz",
-			"integrity": "sha512-PzMcQLazLBkwDEkrNPi9AbjFt6+3I7HKbiYF2XtWQ7wItrHvEOeO3T8Am434zAozWtVP7lrTue1bEfc2nYWeCA==",
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
+			"integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
 			"dev": true,
 			"optional": true
 		},
@@ -3473,9 +3476,9 @@
 			"optional": true
 		},
 		"@esbuild/linux-loong64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.11.tgz",
-			"integrity": "sha512-geWp637tUhNmhL3Xgy4Bj703yXB9dqiLJe05lCUfjSFDrQf9C/8pArusyPUbUbPwlC/EAUjBw32sxuIl/11dZw==",
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
+			"integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -3667,14 +3670,14 @@
 			"dev": true
 		},
 		"@sveltejs/adapter-netlify": {
-			"version": "1.0.0-next.81",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-1.0.0-next.81.tgz",
-			"integrity": "sha512-jWZHw2uqUMJk8lFPzRm0xxmBZoDc430tbeCU9EtYhG+ypze2B6pJAlNTtcN3/J7wapHq19TgEK5oNt4LqORfNg==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-2.0.6.tgz",
+			"integrity": "sha512-9guxI9jG/v/JTr/I1E1YGKppKWRyvs60VuhPJcGBrj2MfoBxR40vhxkrWPFcNJoAdyQUSjqxbg7sZLA4WbNfgA==",
 			"dev": true,
 			"requires": {
 				"@iarna/toml": "^2.2.5",
-				"esbuild": "^0.15.7",
-				"set-cookie-parser": "^2.4.8"
+				"esbuild": "^0.16.3",
+				"set-cookie-parser": "^2.5.1"
 			}
 		},
 		"@sveltejs/kit": {
@@ -4083,174 +4086,176 @@
 			"dev": true
 		},
 		"esbuild": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.11.tgz",
-			"integrity": "sha512-OgHGuhlfZ//mToxjte1D5iiiQgWfJ2GByVMwEC/IuoXsBGkuyK1+KrjYu0laSpnN/L1UmLUCv0s25vObdc1bVg==",
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
+			"integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
 			"dev": true,
 			"requires": {
-				"@esbuild/android-arm": "0.15.11",
-				"@esbuild/linux-loong64": "0.15.11",
-				"esbuild-android-64": "0.15.11",
-				"esbuild-android-arm64": "0.15.11",
-				"esbuild-darwin-64": "0.15.11",
-				"esbuild-darwin-arm64": "0.15.11",
-				"esbuild-freebsd-64": "0.15.11",
-				"esbuild-freebsd-arm64": "0.15.11",
-				"esbuild-linux-32": "0.15.11",
-				"esbuild-linux-64": "0.15.11",
-				"esbuild-linux-arm": "0.15.11",
-				"esbuild-linux-arm64": "0.15.11",
-				"esbuild-linux-mips64le": "0.15.11",
-				"esbuild-linux-ppc64le": "0.15.11",
-				"esbuild-linux-riscv64": "0.15.11",
-				"esbuild-linux-s390x": "0.15.11",
-				"esbuild-netbsd-64": "0.15.11",
-				"esbuild-openbsd-64": "0.15.11",
-				"esbuild-sunos-64": "0.15.11",
-				"esbuild-windows-32": "0.15.11",
-				"esbuild-windows-64": "0.15.11",
-				"esbuild-windows-arm64": "0.15.11"
+				"@esbuild/android-arm": "0.16.17",
+				"@esbuild/android-arm64": "0.16.17",
+				"@esbuild/android-x64": "0.16.17",
+				"@esbuild/darwin-arm64": "0.16.17",
+				"@esbuild/darwin-x64": "0.16.17",
+				"@esbuild/freebsd-arm64": "0.16.17",
+				"@esbuild/freebsd-x64": "0.16.17",
+				"@esbuild/linux-arm": "0.16.17",
+				"@esbuild/linux-arm64": "0.16.17",
+				"@esbuild/linux-ia32": "0.16.17",
+				"@esbuild/linux-loong64": "0.16.17",
+				"@esbuild/linux-mips64el": "0.16.17",
+				"@esbuild/linux-ppc64": "0.16.17",
+				"@esbuild/linux-riscv64": "0.16.17",
+				"@esbuild/linux-s390x": "0.16.17",
+				"@esbuild/linux-x64": "0.16.17",
+				"@esbuild/netbsd-x64": "0.16.17",
+				"@esbuild/openbsd-x64": "0.16.17",
+				"@esbuild/sunos-x64": "0.16.17",
+				"@esbuild/win32-arm64": "0.16.17",
+				"@esbuild/win32-ia32": "0.16.17",
+				"@esbuild/win32-x64": "0.16.17"
+			},
+			"dependencies": {
+				"@esbuild/android-arm64": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
+					"integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/android-x64": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
+					"integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/darwin-arm64": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
+					"integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/darwin-x64": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
+					"integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/freebsd-arm64": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
+					"integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/freebsd-x64": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
+					"integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/linux-arm": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
+					"integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/linux-arm64": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
+					"integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/linux-ia32": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
+					"integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/linux-mips64el": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
+					"integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/linux-ppc64": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
+					"integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/linux-riscv64": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
+					"integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/linux-s390x": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
+					"integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/linux-x64": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
+					"integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/netbsd-x64": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
+					"integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/openbsd-x64": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
+					"integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/sunos-x64": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
+					"integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/win32-arm64": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
+					"integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/win32-ia32": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
+					"integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
+					"dev": true,
+					"optional": true
+				},
+				"@esbuild/win32-x64": {
+					"version": "0.16.17",
+					"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
+					"integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
+					"dev": true,
+					"optional": true
+				}
 			}
-		},
-		"esbuild-android-64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.11.tgz",
-			"integrity": "sha512-rrwoXEiuI1kaw4k475NJpexs8GfJqQUKcD08VR8sKHmuW9RUuTR2VxcupVvHdiGh9ihxL9m3lpqB1kju92Ialw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-android-arm64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.11.tgz",
-			"integrity": "sha512-/hDubOg7BHOhUUsT8KUIU7GfZm5bihqssvqK5PfO4apag7YuObZRZSzViyEKcFn2tPeHx7RKbSBXvAopSHDZJQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-darwin-64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.11.tgz",
-			"integrity": "sha512-1DqHD0ms3AhiwkKnjRUzmiW7JnaJJr5FKrPiR7xuyMwnjDqvNWDdMq4rKSD9OC0piFNK6n0LghsglNMe2MwJtA==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-darwin-arm64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.11.tgz",
-			"integrity": "sha512-OMzhxSbS0lwwrW40HHjRCeVIJTURdXFA8c3GU30MlHKuPCcvWNUIKVucVBtNpJySXmbkQMDJdJNrXzNDyvoqvQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-freebsd-64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.11.tgz",
-			"integrity": "sha512-8dKP26r0/Qyez8nTCwpq60QbuYKOeBygdgOAWGCRalunyeqWRoSZj9TQjPDnTTI9joxd3QYw3UhVZTKxO9QdRg==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-freebsd-arm64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.11.tgz",
-			"integrity": "sha512-aSGiODiukLGGnSg/O9+cGO2QxEacrdCtCawehkWYTt5VX1ni2b9KoxpHCT9h9Y6wGqNHmXFnB47RRJ8BIqZgmQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-32": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.11.tgz",
-			"integrity": "sha512-lsrAfdyJBGx+6aHIQmgqUonEzKYeBnyfJPkT6N2dOf1RoXYYV1BkWB6G02tjsrz1d5wZzaTc3cF+TKmuTo/ZwA==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.11.tgz",
-			"integrity": "sha512-Y2Rh+PcyVhQqXKBTacPCltINN3uIw2xC+dsvLANJ1SpK5NJUtxv8+rqWpjmBgaNWKQT1/uGpMmA9olALy9PLVA==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-arm": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.11.tgz",
-			"integrity": "sha512-TJllTVk5aSyqPFvvcHTvf6Wu1ZKhWpJ/qNmZO8LL/XeB+LXCclm7HQHNEIz6MT7IX8PmlC1BZYrOiw2sXSB95A==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-arm64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.11.tgz",
-			"integrity": "sha512-uhcXiTwTmD4OpxJu3xC5TzAAw6Wzf9O1XGWL448EE9bqGjgV1j+oK3lIHAfsHnuIn8K4nDW8yjX0Sv5S++oRuw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-mips64le": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.11.tgz",
-			"integrity": "sha512-WD61y/R1M4BLe4gxXRypoQ0Ci+Vjf714QYzcPNkiYv5I8K8WDz2ZR8Bm6cqKxd6rD+e/rZgPDbhQ9PCf7TMHmA==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-ppc64le": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.11.tgz",
-			"integrity": "sha512-JVleZS9oPVLTlBhPTWgOwxFWU/wMUdlBwTbGA4GF8c38sLbS13cupj+C8bLq929jU7EMWry4SaL+tKGIaTlqKg==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-riscv64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.11.tgz",
-			"integrity": "sha512-9aLIalZ2HFHIOZpmVU11sEAS9F8TnHw49daEjcgMpBXHFF57VuT9f9/9LKJhw781Gda0P9jDkuCWJ0tFbErvJw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-linux-s390x": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.11.tgz",
-			"integrity": "sha512-sZHtiXXOKsLI3XGBGoYO4qKBzJlb8xNsWmvFiwFMHFzA4AXgDP1KDp7Dawe9C2pavTRBDvl+Ok4n/DHQ59oaTg==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-netbsd-64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.11.tgz",
-			"integrity": "sha512-hUC9yN06K9sg7ju4Vgu9ChAPdsEgtcrcLfyNT5IKwKyfpLvKUwCMZSdF+gRD3WpyZelgTQfJ+pDx5XFbXTlB0A==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-openbsd-64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.11.tgz",
-			"integrity": "sha512-0bBo9SQR4t66Wd91LGMAqmWorzO0TTzVjYiifwoFtel8luFeXuPThQnEm5ztN4g0fnvcp7AnUPPzS/Depf17wQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-sunos-64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.11.tgz",
-			"integrity": "sha512-EuBdTGlsMTjEl1sQnBX2jfygy7iR6CKfvOzi+gEOfhDqbHXsmY1dcpbVtcwHAg9/2yUZSfMJHMAgf1z8M4yyyw==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-windows-32": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.11.tgz",
-			"integrity": "sha512-O0/Wo1Wk6dc0rZSxkvGpmTNIycEznHmkObTFz2VHBhjPsO4ZpCgfGxNkCpz4AdAIeMczpTXt/8d5vdJNKEGC+Q==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-windows-64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.11.tgz",
-			"integrity": "sha512-x977Q4HhNjnHx00b4XLAnTtj5vfbdEvkxaQwC1Zh5AN8g5EX+izgZ6e5QgqJgpzyRNJqh4hkgIJF1pyy1be0mQ==",
-			"dev": true,
-			"optional": true
-		},
-		"esbuild-windows-arm64": {
-			"version": "0.15.11",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.11.tgz",
-			"integrity": "sha512-VwUHFACuBahrvntdcMKZteUZ9HaYrBRODoKe4tIWxguQRvvYoYb7iu5LrcRS/FQx8KPZNaa72zuqwVtHeXsITw==",
-			"dev": true,
-			"optional": true
 		},
 		"escape-string-regexp": {
 			"version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-netlify": "^1.0.0-next.51",
-				"@sveltejs/kit": "next",
+				"@sveltejs/kit": "1.15.8",
 				"@tsconfig/svelte": "^4.0.1",
 				"@typescript-eslint/eslint-plugin": "^5.10.1",
 				"@typescript-eslint/parser": "^5.10.1",
@@ -534,55 +534,56 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.0.0-next.532",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.532.tgz",
-			"integrity": "sha512-g+t+dncoz/DBc1mfwSfBaIBqE5pl0caMUy7yZzjsnyw0WG3AevC04d2KfTOgtOMgXVDnSVqZxlTR+MM5tnKeyw==",
+			"version": "1.15.8",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.15.8.tgz",
+			"integrity": "sha512-xPIF3UbFEA5BBZWFTGGUtSZ0O3DAtmzIp/yZZVdLIfzZ9+geKG3iGSVFnOUdYstjU7JcvJg12UC5MD5xoED59A==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"@sveltejs/vite-plugin-svelte": "^1.1.0",
+				"@sveltejs/vite-plugin-svelte": "^2.1.0",
 				"@types/cookie": "^0.5.1",
 				"cookie": "^0.5.0",
-				"devalue": "^4.1.0",
+				"devalue": "^4.3.0",
+				"esm-env": "^1.0.0",
 				"kleur": "^4.1.5",
-				"magic-string": "^0.26.7",
+				"magic-string": "^0.30.0",
 				"mime": "^3.0.0",
 				"sade": "^1.8.1",
 				"set-cookie-parser": "^2.5.1",
 				"sirv": "^2.0.2",
 				"tiny-glob": "^0.2.9",
-				"undici": "5.12.0"
+				"undici": "~5.22.0"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
 			},
 			"engines": {
-				"node": ">=16.14"
+				"node": "^16.14 || >=18"
 			},
 			"peerDependencies": {
-				"svelte": "^3.44.0",
-				"vite": "^3.1.0"
+				"svelte": "^3.54.0",
+				"vite": "^4.0.0"
 			}
 		},
-		"node_modules/@sveltejs/kit/node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.4.0.tgz",
-			"integrity": "sha512-6QupI/jemMfK+yI2pMtJcu5iO2gtgTfcBdGwMZZt+lgbFELhszbDl6Qjh000HgAV8+XUA+8EY8DusOFk8WhOIg==",
+		"node_modules/@sveltejs/vite-plugin-svelte": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.1.1.tgz",
+			"integrity": "sha512-7YeBDt4us0FiIMNsVXxyaP4Hwyn2/v9x3oqStkHU3ZdIc5O22pGwUwH33wUqYo+7Itdmo8zxJ45Qvfm3H7UUjQ==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^4.3.4",
-				"deepmerge": "^4.2.2",
+				"deepmerge": "^4.3.1",
 				"kleur": "^4.1.5",
-				"magic-string": "^0.26.7",
+				"magic-string": "^0.30.0",
 				"svelte-hmr": "^0.15.1",
-				"vitefu": "^0.2.2"
+				"vitefu": "^0.2.4"
 			},
 			"engines": {
 				"node": "^14.18.0 || >= 16"
 			},
 			"peerDependencies": {
-				"svelte": "^3.44.0",
-				"vite": "^3.0.0"
+				"svelte": "^3.54.0",
+				"vite": "^4.0.0"
 			}
 		},
 		"node_modules/@tsconfig/svelte": {
@@ -1673,6 +1674,12 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/esm-env": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
+			"integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==",
+			"dev": true
+		},
 		"node_modules/espree": {
 			"version": "9.5.1",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
@@ -1869,26 +1876,6 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
-		"node_modules/gauge": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
-			"integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-			"dev": true,
-			"dependencies": {
-				"aproba": "^1.0.3 || ^2.0.0",
-				"color-support": "^1.1.2",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.1",
-				"object-assign": "^4.1.1",
-				"signal-exit": "^3.0.0",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"wide-align": "^1.1.2"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/glob": {
@@ -2203,12 +2190,12 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.26.7",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
-			"integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+			"version": "0.30.0",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+			"integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
 			"dev": true,
 			"dependencies": {
-				"sourcemap-codec": "^1.4.8"
+				"@jridgewell/sourcemap-codec": "^1.4.13"
 			},
 			"engines": {
 				"node": ">=12"
@@ -2611,15 +2598,6 @@
 				"url": "https://github.com/sponsors/mysticatea"
 			}
 		},
-		"node_modules/resolve-from": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -2888,9 +2866,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.52.0.tgz",
-			"integrity": "sha512-FxcnEUOAVfr10vDU5dVgJN19IvqeHQCS1zfe8vayTfis9A2t5Fhx+JDe5uv/C3j//bB1umpLJ6quhgs9xyUbCQ==",
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.58.0.tgz",
+			"integrity": "sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A==",
 			"dev": true,
 			"engines": {
 				"node": ">= 8"
@@ -3209,15 +3187,15 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
-			"integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
+			"integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
 			"dev": true,
 			"dependencies": {
 				"busboy": "^1.6.0"
 			},
 			"engines": {
-				"node": ">=12.18"
+				"node": ">=14.0"
 			}
 		},
 		"node_modules/unist-util-stringify-position": {
@@ -3700,39 +3678,38 @@
 			}
 		},
 		"@sveltejs/kit": {
-			"version": "1.0.0-next.532",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.532.tgz",
-			"integrity": "sha512-g+t+dncoz/DBc1mfwSfBaIBqE5pl0caMUy7yZzjsnyw0WG3AevC04d2KfTOgtOMgXVDnSVqZxlTR+MM5tnKeyw==",
+			"version": "1.15.8",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.15.8.tgz",
+			"integrity": "sha512-xPIF3UbFEA5BBZWFTGGUtSZ0O3DAtmzIp/yZZVdLIfzZ9+geKG3iGSVFnOUdYstjU7JcvJg12UC5MD5xoED59A==",
 			"dev": true,
 			"requires": {
-				"@sveltejs/vite-plugin-svelte": "^1.1.0",
+				"@sveltejs/vite-plugin-svelte": "^2.1.0",
 				"@types/cookie": "^0.5.1",
 				"cookie": "^0.5.0",
-				"devalue": "^4.1.0",
+				"devalue": "^4.3.0",
+				"esm-env": "^1.0.0",
 				"kleur": "^4.1.5",
-				"magic-string": "^0.26.7",
+				"magic-string": "^0.30.0",
 				"mime": "^3.0.0",
 				"sade": "^1.8.1",
 				"set-cookie-parser": "^2.5.1",
 				"sirv": "^2.0.2",
 				"tiny-glob": "^0.2.9",
-				"undici": "5.12.0"
-			},
-			"dependencies": {
-				"@sveltejs/vite-plugin-svelte": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.4.0.tgz",
-					"integrity": "sha512-6QupI/jemMfK+yI2pMtJcu5iO2gtgTfcBdGwMZZt+lgbFELhszbDl6Qjh000HgAV8+XUA+8EY8DusOFk8WhOIg==",
-					"dev": true,
-					"requires": {
-						"debug": "^4.3.4",
-						"deepmerge": "^4.2.2",
-						"kleur": "^4.1.5",
-						"magic-string": "^0.26.7",
-						"svelte-hmr": "^0.15.1",
-						"vitefu": "^0.2.2"
-					}
-				}
+				"undici": "~5.22.0"
+			}
+		},
+		"@sveltejs/vite-plugin-svelte": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.1.1.tgz",
+			"integrity": "sha512-7YeBDt4us0FiIMNsVXxyaP4Hwyn2/v9x3oqStkHU3ZdIc5O22pGwUwH33wUqYo+7Itdmo8zxJ45Qvfm3H7UUjQ==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.3.4",
+				"deepmerge": "^4.3.1",
+				"kleur": "^4.1.5",
+				"magic-string": "^0.30.0",
+				"svelte-hmr": "^0.15.1",
+				"vitefu": "^0.2.4"
 			}
 		},
 		"@tsconfig/svelte": {
@@ -4403,6 +4380,12 @@
 			"integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
 			"dev": true
 		},
+		"esm-env": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
+			"integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==",
+			"dev": true
+		},
 		"espree": {
 			"version": "9.5.1",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
@@ -4555,23 +4538,6 @@
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
 			"optional": true
-		},
-		"gauge": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
-			"integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-			"dev": true,
-			"requires": {
-				"aproba": "^1.0.3 || ^2.0.0",
-				"color-support": "^1.1.2",
-				"console-control-strings": "^1.0.0",
-				"has-unicode": "^2.0.1",
-				"object-assign": "^4.1.1",
-				"signal-exit": "^3.0.0",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"wide-align": "^1.1.2"
-			}
 		},
 		"glob": {
 			"version": "7.2.3",
@@ -4811,12 +4777,12 @@
 			}
 		},
 		"magic-string": {
-			"version": "0.26.7",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
-			"integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
+			"version": "0.30.0",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+			"integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
 			"dev": true,
 			"requires": {
-				"sourcemap-codec": "^1.4.8"
+				"@jridgewell/sourcemap-codec": "^1.4.13"
 			}
 		},
 		"mdsvex": {
@@ -5071,12 +5037,6 @@
 			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
-		"resolve-from": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true
-		},
 		"reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -5262,9 +5222,9 @@
 			}
 		},
 		"svelte": {
-			"version": "3.52.0",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.52.0.tgz",
-			"integrity": "sha512-FxcnEUOAVfr10vDU5dVgJN19IvqeHQCS1zfe8vayTfis9A2t5Fhx+JDe5uv/C3j//bB1umpLJ6quhgs9xyUbCQ==",
+			"version": "3.58.0",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.58.0.tgz",
+			"integrity": "sha512-brIBNNB76mXFmU/Kerm4wFnkskBbluBDCjx/8TcpYRb298Yh2dztS2kQ6bhtjMcvUhd5ynClfwpz5h2gnzdQ1A==",
 			"dev": true
 		},
 		"svelte-check": {
@@ -5433,9 +5393,9 @@
 			"dev": true
 		},
 		"undici": {
-			"version": "5.12.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
-			"integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
+			"version": "5.22.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.0.tgz",
+			"integrity": "sha512-fR9RXCc+6Dxav4P9VV/sp5w3eFiSdOjJYsbtWfd4s5L5C4ogyuVpdKIVHeW0vV1MloM65/f7W45nR9ZxwVdyiA==",
 			"dev": true,
 			"requires": {
 				"busboy": "^1.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "teeline.online",
 			"version": "0.0.1",
 			"dependencies": {
-				"vite": "^3.1.8"
+				"vite": "^4.3.2"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-netlify": "^1.0.0-next.51",
@@ -36,9 +36,145 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.18.tgz",
+			"integrity": "sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.18.tgz",
+			"integrity": "sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.18.tgz",
+			"integrity": "sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.18.tgz",
+			"integrity": "sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.18.tgz",
+			"integrity": "sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.18.tgz",
+			"integrity": "sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.18.tgz",
+			"integrity": "sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.18.tgz",
+			"integrity": "sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.18.tgz",
+			"integrity": "sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"linux"
 			],
 			"engines": {
 				"node": ">=12"
@@ -51,9 +187,175 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.18.tgz",
+			"integrity": "sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==",
+			"cpu": [
+				"mips64el"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.18.tgz",
+			"integrity": "sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.18.tgz",
+			"integrity": "sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==",
+			"cpu": [
+				"riscv64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.18.tgz",
+			"integrity": "sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==",
+			"cpu": [
+				"s390x"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.18.tgz",
+			"integrity": "sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.18.tgz",
+			"integrity": "sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.18.tgz",
+			"integrity": "sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.18.tgz",
+			"integrity": "sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.18.tgz",
+			"integrity": "sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==",
+			"cpu": [
+				"arm64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.18.tgz",
+			"integrity": "sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==",
+			"cpu": [
+				"ia32"
+			],
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.18.tgz",
+			"integrity": "sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==",
+			"cpu": [
+				"x64"
+			],
+			"optional": true,
+			"os": [
+				"win32"
 			],
 			"engines": {
 				"node": ">=12"
@@ -262,7 +564,7 @@
 				"vite": "^3.1.0"
 			}
 		},
-		"node_modules/@sveltejs/vite-plugin-svelte": {
+		"node_modules/@sveltejs/kit/node_modules/@sveltejs/vite-plugin-svelte": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.4.0.tgz",
 			"integrity": "sha512-6QupI/jemMfK+yI2pMtJcu5iO2gtgTfcBdGwMZZt+lgbFELhszbDl6Qjh000HgAV8+XUA+8EY8DusOFk8WhOIg==",
@@ -835,6 +1137,7 @@
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.11.tgz",
 			"integrity": "sha512-OgHGuhlfZ//mToxjte1D5iiiQgWfJ2GByVMwEC/IuoXsBGkuyK1+KrjYu0laSpnN/L1UmLUCv0s25vObdc1bVg==",
+			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
@@ -874,6 +1177,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"android"
@@ -889,6 +1193,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"android"
@@ -904,6 +1209,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"darwin"
@@ -919,6 +1225,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"darwin"
@@ -934,6 +1241,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -949,6 +1257,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -964,6 +1273,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -979,6 +1289,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -994,6 +1305,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1009,6 +1321,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1024,6 +1337,7 @@
 			"cpu": [
 				"mips64el"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1039,6 +1353,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1054,6 +1369,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1069,6 +1385,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1084,6 +1401,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"netbsd"
@@ -1099,6 +1417,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"openbsd"
@@ -1114,6 +1433,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"sunos"
@@ -1129,6 +1449,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -1144,6 +1465,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -1159,6 +1481,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -1548,10 +1871,25 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
-		"node_modules/function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		"node_modules/gauge": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+			"integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+			"dev": true,
+			"dependencies": {
+				"aproba": "^1.0.3 || ^2.0.0",
+				"color-support": "^1.1.2",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.1",
+				"object-assign": "^4.1.1",
+				"signal-exit": "^3.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"wide-align": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/glob": {
 			"version": "7.2.3",
@@ -1644,17 +1982,6 @@
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
 			"dev": true
 		},
-		"node_modules/has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dependencies": {
-				"function-bind": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1739,17 +2066,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/is-core-module": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-			"integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
-			"dependencies": {
-				"has": "^1.0.3"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-extglob": {
@@ -2014,9 +2330,15 @@
 			"dev": true
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+			"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -2134,11 +2456,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -2166,9 +2483,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.18",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
-			"integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
+			"version": "8.4.23",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
+			"integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2177,10 +2494,14 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
-				"nanoid": "^3.3.4",
+				"nanoid": "^3.3.6",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			},
@@ -2290,20 +2611,13 @@
 				"url": "https://github.com/sponsors/mysticatea"
 			}
 		},
-		"node_modules/resolve": {
-			"version": "1.22.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-			"dependencies": {
-				"is-core-module": "^2.9.0",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			},
-			"bin": {
-				"resolve": "bin/resolve"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
+		"node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/reusify": {
@@ -2332,14 +2646,15 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.78.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-			"integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.0.tgz",
+			"integrity": "sha512-ANPhVcyeHvYdQMUyCbczy33nbLzI7RzrBje4uvNiTDJGIMtlKoOStmympwr9OtS1LZxiDmE2wvxHyVhoLtf1KQ==",
 			"bin": {
 				"rollup": "dist/bin/rollup"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=14.18.0",
+				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
@@ -2570,17 +2885,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/supports-preserve-symlinks-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/svelte": {
@@ -2953,14 +3257,13 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "3.1.8",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-3.1.8.tgz",
-			"integrity": "sha512-m7jJe3nufUbuOfotkntGFupinL/fmuTNuQmiVE7cH2IZMuf4UbfbGYMUT3jVWgGYuRVLY9j8NnrRqgw5rr5QTg==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.3.2.tgz",
+			"integrity": "sha512-9R53Mf+TBoXCYejcL+qFbZde+eZveQLDYd9XgULILLC1a5ZwPaqgmdVpL8/uvw2BM/1TzetWjglwm+3RO+xTyw==",
 			"dependencies": {
-				"esbuild": "^0.15.9",
-				"postcss": "^8.4.16",
-				"resolve": "^1.22.1",
-				"rollup": "~2.78.0"
+				"esbuild": "^0.17.5",
+				"postcss": "^8.4.21",
+				"rollup": "^3.21.0"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -2972,12 +3275,17 @@
 				"fsevents": "~2.3.2"
 			},
 			"peerDependencies": {
+				"@types/node": ">= 14",
 				"less": "*",
 				"sass": "*",
 				"stylus": "*",
+				"sugarss": "*",
 				"terser": "^5.4.0"
 			},
 			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
 				"less": {
 					"optional": true
 				},
@@ -2987,9 +3295,78 @@
 				"stylus": {
 					"optional": true
 				},
+				"sugarss": {
+					"optional": true
+				},
 				"terser": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/android-arm": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.18.tgz",
+			"integrity": "sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==",
+			"cpu": [
+				"arm"
+			],
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/@esbuild/linux-loong64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.18.tgz",
+			"integrity": "sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==",
+			"cpu": [
+				"loong64"
+			],
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.18.tgz",
+			"integrity": "sha512-z1lix43jBs6UKjcZVKOw2xx69ffE2aG0PygLL5qJ9OS/gy0Ewd1gW/PUQIOIQGXBHWNywSc0floSKoMFF8aK2w==",
+			"hasInstallScript": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"@esbuild/android-arm": "0.17.18",
+				"@esbuild/android-arm64": "0.17.18",
+				"@esbuild/android-x64": "0.17.18",
+				"@esbuild/darwin-arm64": "0.17.18",
+				"@esbuild/darwin-x64": "0.17.18",
+				"@esbuild/freebsd-arm64": "0.17.18",
+				"@esbuild/freebsd-x64": "0.17.18",
+				"@esbuild/linux-arm": "0.17.18",
+				"@esbuild/linux-arm64": "0.17.18",
+				"@esbuild/linux-ia32": "0.17.18",
+				"@esbuild/linux-loong64": "0.17.18",
+				"@esbuild/linux-mips64el": "0.17.18",
+				"@esbuild/linux-ppc64": "0.17.18",
+				"@esbuild/linux-riscv64": "0.17.18",
+				"@esbuild/linux-s390x": "0.17.18",
+				"@esbuild/linux-x64": "0.17.18",
+				"@esbuild/netbsd-x64": "0.17.18",
+				"@esbuild/openbsd-x64": "0.17.18",
+				"@esbuild/sunos-x64": "0.17.18",
+				"@esbuild/win32-arm64": "0.17.18",
+				"@esbuild/win32-ia32": "0.17.18",
+				"@esbuild/win32-x64": "0.17.18"
 			}
 		},
 		"node_modules/vitefu": {
@@ -3060,12 +3437,134 @@
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.11.tgz",
 			"integrity": "sha512-PzMcQLazLBkwDEkrNPi9AbjFt6+3I7HKbiYF2XtWQ7wItrHvEOeO3T8Am434zAozWtVP7lrTue1bEfc2nYWeCA==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/android-arm64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.18.tgz",
+			"integrity": "sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==",
+			"optional": true
+		},
+		"@esbuild/android-x64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.18.tgz",
+			"integrity": "sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==",
+			"optional": true
+		},
+		"@esbuild/darwin-arm64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.18.tgz",
+			"integrity": "sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==",
+			"optional": true
+		},
+		"@esbuild/darwin-x64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.18.tgz",
+			"integrity": "sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==",
+			"optional": true
+		},
+		"@esbuild/freebsd-arm64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.18.tgz",
+			"integrity": "sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==",
+			"optional": true
+		},
+		"@esbuild/freebsd-x64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.18.tgz",
+			"integrity": "sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==",
+			"optional": true
+		},
+		"@esbuild/linux-arm": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.18.tgz",
+			"integrity": "sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==",
+			"optional": true
+		},
+		"@esbuild/linux-arm64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.18.tgz",
+			"integrity": "sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==",
+			"optional": true
+		},
+		"@esbuild/linux-ia32": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.18.tgz",
+			"integrity": "sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==",
 			"optional": true
 		},
 		"@esbuild/linux-loong64": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.11.tgz",
 			"integrity": "sha512-geWp637tUhNmhL3Xgy4Bj703yXB9dqiLJe05lCUfjSFDrQf9C/8pArusyPUbUbPwlC/EAUjBw32sxuIl/11dZw==",
+			"dev": true,
+			"optional": true
+		},
+		"@esbuild/linux-mips64el": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.18.tgz",
+			"integrity": "sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==",
+			"optional": true
+		},
+		"@esbuild/linux-ppc64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.18.tgz",
+			"integrity": "sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==",
+			"optional": true
+		},
+		"@esbuild/linux-riscv64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.18.tgz",
+			"integrity": "sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==",
+			"optional": true
+		},
+		"@esbuild/linux-s390x": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.18.tgz",
+			"integrity": "sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==",
+			"optional": true
+		},
+		"@esbuild/linux-x64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.18.tgz",
+			"integrity": "sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==",
+			"optional": true
+		},
+		"@esbuild/netbsd-x64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.18.tgz",
+			"integrity": "sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==",
+			"optional": true
+		},
+		"@esbuild/openbsd-x64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.18.tgz",
+			"integrity": "sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==",
+			"optional": true
+		},
+		"@esbuild/sunos-x64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.18.tgz",
+			"integrity": "sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==",
+			"optional": true
+		},
+		"@esbuild/win32-arm64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.18.tgz",
+			"integrity": "sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==",
+			"optional": true
+		},
+		"@esbuild/win32-ia32": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.18.tgz",
+			"integrity": "sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==",
+			"optional": true
+		},
+		"@esbuild/win32-x64": {
+			"version": "0.17.18",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.18.tgz",
+			"integrity": "sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==",
 			"optional": true
 		},
 		"@eslint-community/eslint-utils": {
@@ -3218,20 +3717,22 @@
 				"sirv": "^2.0.2",
 				"tiny-glob": "^0.2.9",
 				"undici": "5.12.0"
-			}
-		},
-		"@sveltejs/vite-plugin-svelte": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.4.0.tgz",
-			"integrity": "sha512-6QupI/jemMfK+yI2pMtJcu5iO2gtgTfcBdGwMZZt+lgbFELhszbDl6Qjh000HgAV8+XUA+8EY8DusOFk8WhOIg==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.3.4",
-				"deepmerge": "^4.2.2",
-				"kleur": "^4.1.5",
-				"magic-string": "^0.26.7",
-				"svelte-hmr": "^0.15.1",
-				"vitefu": "^0.2.2"
+			},
+			"dependencies": {
+				"@sveltejs/vite-plugin-svelte": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.4.0.tgz",
+					"integrity": "sha512-6QupI/jemMfK+yI2pMtJcu5iO2gtgTfcBdGwMZZt+lgbFELhszbDl6Qjh000HgAV8+XUA+8EY8DusOFk8WhOIg==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.3.4",
+						"deepmerge": "^4.2.2",
+						"kleur": "^4.1.5",
+						"magic-string": "^0.26.7",
+						"svelte-hmr": "^0.15.1",
+						"vitefu": "^0.2.2"
+					}
+				}
 			}
 		},
 		"@tsconfig/svelte": {
@@ -3608,6 +4109,7 @@
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.11.tgz",
 			"integrity": "sha512-OgHGuhlfZ//mToxjte1D5iiiQgWfJ2GByVMwEC/IuoXsBGkuyK1+KrjYu0laSpnN/L1UmLUCv0s25vObdc1bVg==",
+			"dev": true,
 			"requires": {
 				"@esbuild/android-arm": "0.15.11",
 				"@esbuild/linux-loong64": "0.15.11",
@@ -3637,120 +4139,140 @@
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.11.tgz",
 			"integrity": "sha512-rrwoXEiuI1kaw4k475NJpexs8GfJqQUKcD08VR8sKHmuW9RUuTR2VxcupVvHdiGh9ihxL9m3lpqB1kju92Ialw==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-android-arm64": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.11.tgz",
 			"integrity": "sha512-/hDubOg7BHOhUUsT8KUIU7GfZm5bihqssvqK5PfO4apag7YuObZRZSzViyEKcFn2tPeHx7RKbSBXvAopSHDZJQ==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-darwin-64": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.11.tgz",
 			"integrity": "sha512-1DqHD0ms3AhiwkKnjRUzmiW7JnaJJr5FKrPiR7xuyMwnjDqvNWDdMq4rKSD9OC0piFNK6n0LghsglNMe2MwJtA==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-darwin-arm64": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.11.tgz",
 			"integrity": "sha512-OMzhxSbS0lwwrW40HHjRCeVIJTURdXFA8c3GU30MlHKuPCcvWNUIKVucVBtNpJySXmbkQMDJdJNrXzNDyvoqvQ==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-freebsd-64": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.11.tgz",
 			"integrity": "sha512-8dKP26r0/Qyez8nTCwpq60QbuYKOeBygdgOAWGCRalunyeqWRoSZj9TQjPDnTTI9joxd3QYw3UhVZTKxO9QdRg==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-freebsd-arm64": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.11.tgz",
 			"integrity": "sha512-aSGiODiukLGGnSg/O9+cGO2QxEacrdCtCawehkWYTt5VX1ni2b9KoxpHCT9h9Y6wGqNHmXFnB47RRJ8BIqZgmQ==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-32": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.11.tgz",
 			"integrity": "sha512-lsrAfdyJBGx+6aHIQmgqUonEzKYeBnyfJPkT6N2dOf1RoXYYV1BkWB6G02tjsrz1d5wZzaTc3cF+TKmuTo/ZwA==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-64": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.11.tgz",
 			"integrity": "sha512-Y2Rh+PcyVhQqXKBTacPCltINN3uIw2xC+dsvLANJ1SpK5NJUtxv8+rqWpjmBgaNWKQT1/uGpMmA9olALy9PLVA==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-arm": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.11.tgz",
 			"integrity": "sha512-TJllTVk5aSyqPFvvcHTvf6Wu1ZKhWpJ/qNmZO8LL/XeB+LXCclm7HQHNEIz6MT7IX8PmlC1BZYrOiw2sXSB95A==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-arm64": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.11.tgz",
 			"integrity": "sha512-uhcXiTwTmD4OpxJu3xC5TzAAw6Wzf9O1XGWL448EE9bqGjgV1j+oK3lIHAfsHnuIn8K4nDW8yjX0Sv5S++oRuw==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-mips64le": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.11.tgz",
 			"integrity": "sha512-WD61y/R1M4BLe4gxXRypoQ0Ci+Vjf714QYzcPNkiYv5I8K8WDz2ZR8Bm6cqKxd6rD+e/rZgPDbhQ9PCf7TMHmA==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-ppc64le": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.11.tgz",
 			"integrity": "sha512-JVleZS9oPVLTlBhPTWgOwxFWU/wMUdlBwTbGA4GF8c38sLbS13cupj+C8bLq929jU7EMWry4SaL+tKGIaTlqKg==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-riscv64": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.11.tgz",
 			"integrity": "sha512-9aLIalZ2HFHIOZpmVU11sEAS9F8TnHw49daEjcgMpBXHFF57VuT9f9/9LKJhw781Gda0P9jDkuCWJ0tFbErvJw==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-s390x": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.11.tgz",
 			"integrity": "sha512-sZHtiXXOKsLI3XGBGoYO4qKBzJlb8xNsWmvFiwFMHFzA4AXgDP1KDp7Dawe9C2pavTRBDvl+Ok4n/DHQ59oaTg==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-netbsd-64": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.11.tgz",
 			"integrity": "sha512-hUC9yN06K9sg7ju4Vgu9ChAPdsEgtcrcLfyNT5IKwKyfpLvKUwCMZSdF+gRD3WpyZelgTQfJ+pDx5XFbXTlB0A==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-openbsd-64": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.11.tgz",
 			"integrity": "sha512-0bBo9SQR4t66Wd91LGMAqmWorzO0TTzVjYiifwoFtel8luFeXuPThQnEm5ztN4g0fnvcp7AnUPPzS/Depf17wQ==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-sunos-64": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.11.tgz",
 			"integrity": "sha512-EuBdTGlsMTjEl1sQnBX2jfygy7iR6CKfvOzi+gEOfhDqbHXsmY1dcpbVtcwHAg9/2yUZSfMJHMAgf1z8M4yyyw==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-32": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.11.tgz",
 			"integrity": "sha512-O0/Wo1Wk6dc0rZSxkvGpmTNIycEznHmkObTFz2VHBhjPsO4ZpCgfGxNkCpz4AdAIeMczpTXt/8d5vdJNKEGC+Q==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-64": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.11.tgz",
 			"integrity": "sha512-x977Q4HhNjnHx00b4XLAnTtj5vfbdEvkxaQwC1Zh5AN8g5EX+izgZ6e5QgqJgpzyRNJqh4hkgIJF1pyy1be0mQ==",
+			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-arm64": {
 			"version": "0.15.11",
 			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.11.tgz",
 			"integrity": "sha512-VwUHFACuBahrvntdcMKZteUZ9HaYrBRODoKe4tIWxguQRvvYoYb7iu5LrcRS/FQx8KPZNaa72zuqwVtHeXsITw==",
+			"dev": true,
 			"optional": true
 		},
 		"escape-string-regexp": {
@@ -4034,10 +4556,22 @@
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
 			"optional": true
 		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		"gauge": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+			"integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+			"dev": true,
+			"requires": {
+				"aproba": "^1.0.3 || ^2.0.0",
+				"color-support": "^1.1.2",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.1",
+				"object-assign": "^4.1.1",
+				"signal-exit": "^3.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"wide-align": "^1.1.2"
+			}
 		},
 		"glob": {
 			"version": "7.2.3",
@@ -4109,14 +4643,6 @@
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
 			"dev": true
 		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
 		"has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4182,14 +4708,6 @@
 			"devOptional": true,
 			"requires": {
 				"binary-extensions": "^2.0.0"
-			}
-		},
-		"is-core-module": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-			"integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
-			"requires": {
-				"has": "^1.0.3"
 			}
 		},
 		"is-extglob": {
@@ -4384,9 +4902,9 @@
 			"dev": true
 		},
 		"nanoid": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+			"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -4468,11 +4986,6 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-		},
 		"path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -4491,11 +5004,11 @@
 			"devOptional": true
 		},
 		"postcss": {
-			"version": "8.4.18",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
-			"integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
+			"version": "8.4.23",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
+			"integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
 			"requires": {
-				"nanoid": "^3.3.4",
+				"nanoid": "^3.3.6",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			}
@@ -4558,15 +5071,11 @@
 			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
-		"resolve": {
-			"version": "1.22.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-			"requires": {
-				"is-core-module": "^2.9.0",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			}
+		"resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true
 		},
 		"reusify": {
 			"version": "1.0.4",
@@ -4584,9 +5093,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.78.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-			"integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.0.tgz",
+			"integrity": "sha512-ANPhVcyeHvYdQMUyCbczy33nbLzI7RzrBje4uvNiTDJGIMtlKoOStmympwr9OtS1LZxiDmE2wvxHyVhoLtf1KQ==",
 			"requires": {
 				"fsevents": "~2.3.2"
 			}
@@ -4751,11 +5260,6 @@
 			"requires": {
 				"has-flag": "^4.0.0"
 			}
-		},
-		"supports-preserve-symlinks-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
 		},
 		"svelte": {
 			"version": "3.52.0",
@@ -4966,15 +5470,57 @@
 			}
 		},
 		"vite": {
-			"version": "3.1.8",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-3.1.8.tgz",
-			"integrity": "sha512-m7jJe3nufUbuOfotkntGFupinL/fmuTNuQmiVE7cH2IZMuf4UbfbGYMUT3jVWgGYuRVLY9j8NnrRqgw5rr5QTg==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.3.2.tgz",
+			"integrity": "sha512-9R53Mf+TBoXCYejcL+qFbZde+eZveQLDYd9XgULILLC1a5ZwPaqgmdVpL8/uvw2BM/1TzetWjglwm+3RO+xTyw==",
 			"requires": {
-				"esbuild": "^0.15.9",
+				"esbuild": "^0.17.5",
 				"fsevents": "~2.3.2",
-				"postcss": "^8.4.16",
-				"resolve": "^1.22.1",
-				"rollup": "~2.78.0"
+				"postcss": "^8.4.21",
+				"rollup": "^3.21.0"
+			},
+			"dependencies": {
+				"@esbuild/android-arm": {
+					"version": "0.17.18",
+					"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.18.tgz",
+					"integrity": "sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==",
+					"optional": true
+				},
+				"@esbuild/linux-loong64": {
+					"version": "0.17.18",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.18.tgz",
+					"integrity": "sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==",
+					"optional": true
+				},
+				"esbuild": {
+					"version": "0.17.18",
+					"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.18.tgz",
+					"integrity": "sha512-z1lix43jBs6UKjcZVKOw2xx69ffE2aG0PygLL5qJ9OS/gy0Ewd1gW/PUQIOIQGXBHWNywSc0floSKoMFF8aK2w==",
+					"requires": {
+						"@esbuild/android-arm": "0.17.18",
+						"@esbuild/android-arm64": "0.17.18",
+						"@esbuild/android-x64": "0.17.18",
+						"@esbuild/darwin-arm64": "0.17.18",
+						"@esbuild/darwin-x64": "0.17.18",
+						"@esbuild/freebsd-arm64": "0.17.18",
+						"@esbuild/freebsd-x64": "0.17.18",
+						"@esbuild/linux-arm": "0.17.18",
+						"@esbuild/linux-arm64": "0.17.18",
+						"@esbuild/linux-ia32": "0.17.18",
+						"@esbuild/linux-loong64": "0.17.18",
+						"@esbuild/linux-mips64el": "0.17.18",
+						"@esbuild/linux-ppc64": "0.17.18",
+						"@esbuild/linux-riscv64": "0.17.18",
+						"@esbuild/linux-s390x": "0.17.18",
+						"@esbuild/linux-x64": "0.17.18",
+						"@esbuild/netbsd-x64": "0.17.18",
+						"@esbuild/openbsd-x64": "0.17.18",
+						"@esbuild/sunos-x64": "0.17.18",
+						"@esbuild/win32-arm64": "0.17.18",
+						"@esbuild/win32-ia32": "0.17.18",
+						"@esbuild/win32-x64": "0.17.18"
+					}
+				}
 			}
 		},
 		"vitefu": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,8 @@
 				"mdsvex": "^0.10.6",
 				"prettier": "^2.5.1",
 				"prettier-plugin-svelte": "^2.5.0",
-				"svelte": "^3.44.0",
-				"svelte-check": "^2.10.3",
+				"svelte": "^3.58.0",
+				"svelte-check": "^3.2.0",
 				"svelte-preprocess": "^5.0.3",
 				"tslib": "^2.3.1",
 				"typescript": "~5.0.4"
@@ -612,16 +612,6 @@
 			"resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.6.tgz",
 			"integrity": "sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==",
 			"dev": true
-		},
-		"node_modules/@types/sass": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.45.0.tgz",
-			"integrity": "sha512-jn7qwGFmJHwUSphV8zZneO3GmtlgLsmhs/LQyVvQbIIa+fzGMUiHI4HXJZL3FT8MJmgXWbLGiVVY7ElvHq6vDA==",
-			"deprecated": "This is a stub types definition. sass provides its own type definitions, so you do not need this installed.",
-			"dev": true,
-			"dependencies": {
-				"sass": "*"
-			}
 		},
 		"node_modules/@types/unist": {
 			"version": "2.0.6",
@@ -1994,7 +1984,8 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
 			"integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
-			"devOptional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
@@ -2704,7 +2695,8 @@
 			"version": "1.62.0",
 			"resolved": "https://registry.npmjs.org/sass/-/sass-1.62.0.tgz",
 			"integrity": "sha512-Q4USplo4pLYgCi+XlipZCWUQz5pkg/ruSSgJ0WRDSb/+3z9tXUOkQ7QPYn4XrhZKYAK4HlpaQecRwKLJX6+DBg==",
-			"devOptional": true,
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"chokidar": ">=3.0.0 <4.0.0",
 				"immutable": "^4.0.0",
@@ -2805,12 +2797,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/sourcemap-codec": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-			"dev": true
-		},
 		"node_modules/streamsearch": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -2878,128 +2864,25 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "2.10.3",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.10.3.tgz",
-			"integrity": "sha512-Nt1aWHTOKFReBpmJ1vPug0aGysqPwJh2seM1OvICfM2oeyaA62mOiy5EvkXhltGfhCcIQcq2LoE0l1CwcWPjlw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.2.0.tgz",
+			"integrity": "sha512-6ZnscN8dHEN5Eq5LgIzjj07W9nc9myyBH+diXsUAuiY/3rt0l65/LCIQYlIuoFEjp2F1NhXqZiJwV9omPj9tMw==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.9",
+				"@jridgewell/trace-mapping": "^0.3.17",
 				"chokidar": "^3.4.1",
 				"fast-glob": "^3.2.7",
 				"import-fresh": "^3.2.1",
 				"picocolors": "^1.0.0",
 				"sade": "^1.7.4",
-				"svelte-preprocess": "^4.0.0",
-				"typescript": "*"
+				"svelte-preprocess": "^5.0.3",
+				"typescript": "^5.0.3"
 			},
 			"bin": {
 				"svelte-check": "bin/svelte-check"
 			},
 			"peerDependencies": {
-				"svelte": "^3.24.0"
-			}
-		},
-		"node_modules/svelte-check/node_modules/magic-string": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-			"dev": true,
-			"dependencies": {
-				"sourcemap-codec": "^1.4.8"
-			}
-		},
-		"node_modules/svelte-check/node_modules/sorcery": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
-			"integrity": "sha512-R5ocFmKZQFfSTstfOtHjJuAwbpGyf9qjQa1egyhvXSbM7emjrtLXtGdZsDJDABC85YBfVvrOiGWKSYXPKdvP1g==",
-			"dev": true,
-			"dependencies": {
-				"buffer-crc32": "^0.2.5",
-				"minimist": "^1.2.0",
-				"sander": "^0.5.0",
-				"sourcemap-codec": "^1.3.0"
-			},
-			"bin": {
-				"sorcery": "bin/index.js"
-			}
-		},
-		"node_modules/svelte-check/node_modules/svelte-preprocess": {
-			"version": "4.10.7",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
-			"integrity": "sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"@types/pug": "^2.0.4",
-				"@types/sass": "^1.16.0",
-				"detect-indent": "^6.0.0",
-				"magic-string": "^0.25.7",
-				"sorcery": "^0.10.0",
-				"strip-indent": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 9.11.2"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.10.2",
-				"coffeescript": "^2.5.1",
-				"less": "^3.11.3 || ^4.0.0",
-				"postcss": "^7 || ^8",
-				"postcss-load-config": "^2.1.0 || ^3.0.0 || ^4.0.0",
-				"pug": "^3.0.0",
-				"sass": "^1.26.8",
-				"stylus": "^0.55.0",
-				"sugarss": "^2.0.0",
-				"svelte": "^3.23.0",
-				"typescript": "^3.9.5 || ^4.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@babel/core": {
-					"optional": true
-				},
-				"coffeescript": {
-					"optional": true
-				},
-				"less": {
-					"optional": true
-				},
-				"node-sass": {
-					"optional": true
-				},
-				"postcss": {
-					"optional": true
-				},
-				"postcss-load-config": {
-					"optional": true
-				},
-				"pug": {
-					"optional": true
-				},
-				"sass": {
-					"optional": true
-				},
-				"stylus": {
-					"optional": true
-				},
-				"sugarss": {
-					"optional": true
-				},
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/svelte-check/node_modules/typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-			"dev": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=4.2.0"
+				"svelte": "^3.55.0"
 			}
 		},
 		"node_modules/svelte-hmr": {
@@ -3738,15 +3621,6 @@
 			"resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.6.tgz",
 			"integrity": "sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==",
 			"dev": true
-		},
-		"@types/sass": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.45.0.tgz",
-			"integrity": "sha512-jn7qwGFmJHwUSphV8zZneO3GmtlgLsmhs/LQyVvQbIIa+fzGMUiHI4HXJZL3FT8MJmgXWbLGiVVY7ElvHq6vDA==",
-			"dev": true,
-			"requires": {
-				"sass": "*"
-			}
 		},
 		"@types/unist": {
 			"version": "2.0.6",
@@ -4630,7 +4504,8 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
 			"integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
-			"devOptional": true
+			"optional": true,
+			"peer": true
 		},
 		"import-fresh": {
 			"version": "3.3.0",
@@ -5110,7 +4985,8 @@
 			"version": "1.62.0",
 			"resolved": "https://registry.npmjs.org/sass/-/sass-1.62.0.tgz",
 			"integrity": "sha512-Q4USplo4pLYgCi+XlipZCWUQz5pkg/ruSSgJ0WRDSb/+3z9tXUOkQ7QPYn4XrhZKYAK4HlpaQecRwKLJX6+DBg==",
-			"devOptional": true,
+			"optional": true,
+			"peer": true,
 			"requires": {
 				"chokidar": ">=3.0.0 <4.0.0",
 				"immutable": "^4.0.0",
@@ -5181,12 +5057,6 @@
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
 		},
-		"sourcemap-codec": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-			"dev": true
-		},
 		"streamsearch": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -5233,62 +5103,19 @@
 			"dev": true
 		},
 		"svelte-check": {
-			"version": "2.10.3",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-2.10.3.tgz",
-			"integrity": "sha512-Nt1aWHTOKFReBpmJ1vPug0aGysqPwJh2seM1OvICfM2oeyaA62mOiy5EvkXhltGfhCcIQcq2LoE0l1CwcWPjlw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.2.0.tgz",
+			"integrity": "sha512-6ZnscN8dHEN5Eq5LgIzjj07W9nc9myyBH+diXsUAuiY/3rt0l65/LCIQYlIuoFEjp2F1NhXqZiJwV9omPj9tMw==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/trace-mapping": "^0.3.9",
+				"@jridgewell/trace-mapping": "^0.3.17",
 				"chokidar": "^3.4.1",
 				"fast-glob": "^3.2.7",
 				"import-fresh": "^3.2.1",
 				"picocolors": "^1.0.0",
 				"sade": "^1.7.4",
-				"svelte-preprocess": "^4.0.0",
-				"typescript": "*"
-			},
-			"dependencies": {
-				"magic-string": {
-					"version": "0.25.9",
-					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-					"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-					"dev": true,
-					"requires": {
-						"sourcemap-codec": "^1.4.8"
-					}
-				},
-				"sorcery": {
-					"version": "0.10.0",
-					"resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
-					"integrity": "sha512-R5ocFmKZQFfSTstfOtHjJuAwbpGyf9qjQa1egyhvXSbM7emjrtLXtGdZsDJDABC85YBfVvrOiGWKSYXPKdvP1g==",
-					"dev": true,
-					"requires": {
-						"buffer-crc32": "^0.2.5",
-						"minimist": "^1.2.0",
-						"sander": "^0.5.0",
-						"sourcemap-codec": "^1.3.0"
-					}
-				},
-				"svelte-preprocess": {
-					"version": "4.10.7",
-					"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
-					"integrity": "sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==",
-					"dev": true,
-					"requires": {
-						"@types/pug": "^2.0.4",
-						"@types/sass": "^1.16.0",
-						"detect-indent": "^6.0.0",
-						"magic-string": "^0.25.7",
-						"sorcery": "^0.10.0",
-						"strip-indent": "^3.0.0"
-					}
-				},
-				"typescript": {
-					"version": "4.9.5",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-					"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-					"dev": true
-				}
+				"svelte-preprocess": "^5.0.3",
+				"typescript": "^5.0.3"
 			}
 		},
 		"svelte-hmr": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-netlify": "^1.0.0-next.51",
-		"@sveltejs/kit": "next",
+		"@sveltejs/kit": "1.15.8",
 		"@tsconfig/svelte": "^4.0.1",
 		"@typescript-eslint/eslint-plugin": "^5.10.1",
 		"@typescript-eslint/parser": "^5.10.1",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
 		"mdsvex": "^0.10.6",
 		"prettier": "^2.5.1",
 		"prettier-plugin-svelte": "^2.5.0",
-		"svelte": "^3.44.0",
-		"svelte-check": "^2.10.3",
+		"svelte": "^3.58.0",
+		"svelte-check": "^3.2.0",
 		"svelte-preprocess": "^5.0.3",
 		"tslib": "^2.3.1",
 		"typescript": "~5.0.4"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"format": "prettier --plugin-search-dir . --write ."
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-netlify": "^1.0.0-next.51",
+		"@sveltejs/adapter-netlify": "^2.0.6",
 		"@sveltejs/kit": "1.15.8",
 		"@tsconfig/svelte": "^4.0.1",
 		"@typescript-eslint/eslint-plugin": "^5.10.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"vite": "^3.1.8"
+		"vite": "^4.3.2"
 	}
 }


### PR DESCRIPTION
Part of a little dependency tidying, opted to move `vite` from 3 to 4. This had a couple of knock-on effects so I wound up making a little bundle of it