### PR TITLE
Deduplication and general tidying 

### DIFF
--- a/src/learn-content/connecting-letters.svx
+++ b/src/learn-content/connecting-letters.svx
@@ -11,9 +11,9 @@ description: How and why to join letters together in Teeline shorthand
     import SyllabusLink from '$lib/syllabusLink.svelte'
 
     import outlines from '../data/outlines.json'
-	import { findMatchingSpecialOutline } from '../scripts/helpers.ts'
+	import { findMatchingOutline } from '../scripts/helpers.ts'
 
-	const conferenceOutline: OutlineObject = findMatchingSpecialOutline('conference', outlines);
+	const conferenceOutline: OutlineObject = findMatchingOutline('conference', outlines);
 </script> 
 
 The full process going on in the shorthand writer's brain is as follows:

--- a/src/learn-content/special-outlines.svx
+++ b/src/learn-content/special-outlines.svx
@@ -6,14 +6,14 @@ descriptions: When Teeline shorthand needs its own shorthand, look no further th
 <script>
     import OutlineCardsSideBySide from '$lib/cards/OutlineCardsSideBySide.svelte'
     import outlines from '../data/outlines.json'
-	import { findMatchingSpecialOutline } from '../scripts/helpers.ts'
+	import { findMatchingOutline } from '../scripts/helpers.ts'
     import SyllabusLink from '$lib/syllabusLink.svelte'
 
-	const dOutline = findMatchingSpecialOutline('ladies and gentlemen', outlines);
-	const tOutline = findMatchingSpecialOutline('on the other hand', outlines);
+	const dOutline = findMatchingOutline('ladies and gentlemen', outlines);
+	const tOutline = findMatchingOutline('on the other hand', outlines);
 
-    const governmentOutline = findMatchingSpecialOutline('government', outlines);
-    const satisfactoryOutline = findMatchingSpecialOutline('satisfactory', outlines);
+    const governmentOutline = findMatchingOutline('government', outlines);
+    const satisfactoryOutline = findMatchingOutline('satisfactory', outlines);
 </script> 
 
 There are words and turns of phrases so common that it makes sense to have succinct versions of them, even by the standards of Teeline. These abbreviated - or sometimes straight up symbolic - words are called **special outlines**.

--- a/src/lib/cards/OutlineCardFlipping.svelte
+++ b/src/lib/cards/OutlineCardFlipping.svelte
@@ -2,9 +2,9 @@
 	import type { OutlineObject } from '../../data/interfaces/interfaces';
 	import OutlineSvg from './OutlineSVG.svelte';
 	import { prettify } from '../../scripts/helpers';
-  
+
 	export let outlineObject: OutlineObject;
-	export let outlineFirst;
+	export let outlineFirst: boolean;
 </script>
 
 <div class="flip-card">
@@ -12,9 +12,7 @@
 		<div class="flip-card-front">
 			<div class="svg-container">
 				{#if outlineFirst}
-					<div class="svg-container">
-						<OutlineSvg {outlineObject} />
-					</div>
+					<OutlineSvg {outlineObject} />
 				{:else}
 					<div>{prettify(outlineObject.specialOutlineMeanings)}</div>
 				{/if}
@@ -41,7 +39,6 @@
 		perspective: 1000px;
 		margin: 5vw auto;
 	}
-
 	.flip-card-inner {
 		position: relative;
 		width: 100%;
@@ -50,11 +47,9 @@
 		transition: transform 0.8s;
 		transform-style: preserve-3d;
 	}
-
 	.flip-card:hover .flip-card-inner {
 		transform: rotateY(180deg);
 	}
-
 	.flip-card-front,
 	.flip-card-back {
 		position: absolute;
@@ -66,13 +61,11 @@
 		border-radius: 10px;
 		/* transform: perspective(1000px) rotateX(4deg) rotateY(-16deg) rotateZ(4deg); */
 	}
-
 	.flip-card-front {
 		background-color: white;
 		color: black;
 		display: flex;
 	}
-
 	.flip-card-back {
 		background-color: white;
 		transform: rotateY(180deg);
@@ -81,7 +74,6 @@
 		justify-content: center;
 		align-items: center;
 	}
-
 	.svg-container {
 		width: 60%;
 		margin: auto;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,5 @@
 <script>
 	import HomepageSection from '$lib/homepageSection.svelte';
-	import outlines from '../data/outlines.json';
 </script>
 
 <svelte:head>

--- a/src/routes/learn/+page.svelte
+++ b/src/routes/learn/+page.svelte
@@ -8,7 +8,7 @@
 
 	const sectionsArray = [];
 
-	for (const [key, value] of Object.entries(learnSections)) {
+	for (const key of Object.keys(learnSections)) {
 		sectionsArray.push(key.replace('../../learn-content/', '').replace('.svx', ''));
 	}
 </script>

--- a/src/routes/outlines/+page.svelte
+++ b/src/routes/outlines/+page.svelte
@@ -2,50 +2,27 @@
 	import type { OutlineObject } from '../../data/interfaces/interfaces';
 	import OutlineCardAnimated from '$lib/cards/OutlineCardAnimated.svelte';
 	import Toggle from '../../lib/toggle.svelte';
-	import outlines from '../../data/outlines.json';
-	import { findMatchingOutline, sortOutlinesAlphabetically } from '../../scripts/helpers';
-	import { disemvowelWord } from '../../scripts/disemvowel';
+	import allOutlines from '../../data/outlines.json';
+	import { outlineMatchesSearchTerm, sortOutlinesAlphabetically } from '../../scripts/helpers';
 
-	let displayedOutlines: OutlineObject[] = outlines;
+	let displayedOutlines: OutlineObject[] = allOutlines;
 	let alphabetToggleOn = false;
 	let searchTerm = null;
 
-	const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+	const alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
 
-	const lowerCaseAlphabet = alphabet.map((letter) => letter.toLocaleLowerCase());
-
-	let alphabetOutlines = outlines.filter((outline) =>
-		lowerCaseAlphabet.some(
-			(letter) => outline.letterGroupings && outline.letterGroupings.includes(letter)
-		)
+	const alphabetOutlines = allOutlines.filter((outline) =>
+		alphabet.some((letter) => outline.letterGroupings && outline.letterGroupings.includes(letter))
 	);
 
 	const toggleAlphabetFilter = () => {
-		displayedOutlines = alphabetToggleOn ? outlines : alphabetOutlines;
-		alphabetToggleOn = alphabetToggleOn ? false : true;
-
+		displayedOutlines = alphabetToggleOn ? allOutlines : alphabetOutlines;
+		alphabetToggleOn = !alphabetToggleOn;
 		searchTerm = null;
 	};
 
 	const filterOutlines = (outlines: OutlineObject[], searchTerm: string) => {
-		if (alphabetToggleOn) {
-			displayedOutlines = alphabetOutlines.filter((outline) => {
-				return (
-					(outline.specialOutlineMeanings &&
-						outline.specialOutlineMeanings.join('').includes(searchTerm)) ||
-					(outline.letterGroupings && outline.letterGroupings.join('').includes(searchTerm))
-				);
-			});
-		} else {
-			displayedOutlines = outlines.filter((outline) => {
-				return (
-					(outline.specialOutlineMeanings &&
-						outline.specialOutlineMeanings.join('').includes(searchTerm)) ||
-					(outline.letterGroupings && outline.letterGroupings.join('').includes(searchTerm)) ||
-					(outline.letterGroupings && outline.letterGroupings.includes(disemvowelWord(searchTerm)))
-				);
-			});
-		}
+		displayedOutlines = outlines.filter((outline) => outlineMatchesSearchTerm(outline, searchTerm));
 	};
 </script>
 
@@ -63,7 +40,10 @@
 		class="search-input"
 		placeholder="Search for outlines..."
 		bind:value={searchTerm}
-		on:input={() => filterOutlines(outlines, searchTerm)}
+		on:input={() => {
+			const outlinesToFilter = alphabetToggleOn ? alphabetOutlines : allOutlines;
+			filterOutlines(outlinesToFilter, searchTerm.trim());
+		}}
 	/>
 </div>
 
@@ -83,14 +63,6 @@
 		flex-direction: column;
 		row-gap: 30px;
 	}
-
-	@media (min-width: 1025px) {
-		.animated-container {
-			display: grid;
-			column-gap: 30px;
-			grid-template-columns: repeat(6, 1fr);
-		}
-	}
 	.filters-container {
 		margin: 0 auto 2rem auto;
 		width: max-content;
@@ -99,5 +71,12 @@
 		margin: 10rem auto;
 		text-align: center;
 		font-size: 1.8rem;
+	}
+	@media (min-width: 1025px) {
+		.animated-container {
+			display: grid;
+			column-gap: 30px;
+			grid-template-columns: repeat(6, 1fr);
+		}
 	}
 </style>

--- a/src/routes/revise/+page.svelte
+++ b/src/routes/revise/+page.svelte
@@ -1,32 +1,28 @@
 <script lang="ts">
 	import type { OutlineObject } from '../../data/interfaces/interfaces';
-	import outlines from '../../data/outlines.json';
+	import allOutlines from '../../data/outlines.json';
 	import FlippingOutlineCard from '../../lib/cards/OutlineCardFlipping.svelte';
 	import Toggle from '../../lib/toggle.svelte';
 	import { shuffleOutlines } from '../../scripts/helpers';
 
-	const shuffledOutlines: OutlineObject[] = shuffleOutlines(outlines);
+	const shuffledSpecialOutlines: OutlineObject[] = shuffleOutlines(
+		allOutlines.filter((outline) => outline.specialOutlineMeanings)
+	);
 
 	let counter = 0;
-	let outlineObject = shuffledOutlines[counter];
+	let outlineObject = shuffledSpecialOutlines[counter];
 	let outlineFirst = false;
 
 	const changeOutline = () => {
-		if (counter === outlines.length - 1) counter = 0;
-		else counter++;
-		console.log(counter);
-		outlineObject = shuffledOutlines[counter];
+		counter === allOutlines.length - 1 ? (counter = 0) : counter++;
+		outlineObject = shuffledSpecialOutlines[counter];
 	};
 
-	const handleKeydown = (event) => {
-		if (event.keyCode === 32) {
-			changeOutline();
-		}
+	const handleKeydown = (event: { keyCode: number }) => {
+		event.keyCode === 32 ? changeOutline() : null;
 	};
 
-	const toggleCardOrientation = () => {
-		outlineFirst = !outlineFirst;
-	};
+	const toggleCardOrientation = () => (outlineFirst = !outlineFirst);
 </script>
 
 <svelte:head>
@@ -58,25 +54,20 @@
 	.content {
 		padding: 20px 0;
 	}
-
 	.info-container {
 		text-align: center;
 	}
-
 	.button-container {
 		text-align: center;
 	}
-
 	button {
 		font-size: 2rem;
 		border-radius: 10px;
 		padding: 10px 20px;
 	}
-
 	.flipcard-container {
 		width: 100%;
 	}
-
 	@media (min-width: 1025px) {
 		.flipcard-container {
 			width: 30%;

--- a/src/scripts/disemvowel.ts
+++ b/src/scripts/disemvowel.ts
@@ -1,10 +1,10 @@
 export const disemvowelWord = (word: string) => {
 	const isVowel = (letter: string) => {
-		return ['a', 'e', 'i', 'o', 'u'].indexOf(letter.toLowerCase()) !== -1;
+		return ['a', 'e', 'i', 'o', 'u'].includes(letter.toLowerCase());
 	};
-
 	const firstLetter = word.charAt(0);
 	const finalLetter = word.charAt(word.length - 1);
+	const finalLetterIsSoundedVowel = ['a', 'i', 'o', 'u'].includes(finalLetter.toLowerCase());
 	const wordNoVowelsOrDoubles = word
 		.replace('bb', 'b')
 		.replace('dd', 'd')
@@ -21,29 +21,22 @@ export const disemvowelWord = (word: string) => {
 		.replace('ck', 'c')
 		.replace(/[aeiou]/gi, '');
 	if (word.length === 1) return word;
-	else if (
-		isVowel(firstLetter) &&
-		(finalLetter === 'o' || finalLetter === 'a' || finalLetter === 'i')
-	)
+	else if (isVowel(firstLetter) && finalLetterIsSoundedVowel)
 		return firstLetter + wordNoVowelsOrDoubles + finalLetter;
-	else if (
-		!isVowel(firstLetter) &&
-		(finalLetter === 'o' || finalLetter === 'a' || finalLetter === 'i')
-	)
+	else if (!isVowel(firstLetter) && finalLetterIsSoundedVowel)
 		return wordNoVowelsOrDoubles + finalLetter;
 	else if (isVowel(firstLetter)) return firstLetter + wordNoVowelsOrDoubles;
 	else return wordNoVowelsOrDoubles;
 };
 
 export const disemvowelBodyOfText = (text: string) => {
-	const stringArray = text.split(' ');
-	const disemvoweledStringArray = stringArray.map((word) => disemvowelWord(word));
+	const disemvoweledStringArray = text.split(' ').map((word) => disemvowelWord(word));
 	const disemvoweledText = disemvoweledStringArray.join(' ');
 	return disemvoweledText;
 };
 
-const testSentence =
-	'All men live enveloped in whale-lines. All are born with halters round their necks; but it is only when caught in the swift, sudden turn of death, that mortals realize the silent, subtle, everpresent perils of life.';
+// const testSentence =
+// 'All men live enveloped in whale-lines. All are born with halters round their necks; but it is only when caught in the swift, sudden turn of death, that mortals realize the silent, subtle, everpresent perils of life.';
 
 // console.log(testSentence);
 // console.log(disemvowelBodyOfText(testSentence));

--- a/src/scripts/helpers.ts
+++ b/src/scripts/helpers.ts
@@ -1,17 +1,18 @@
 import type { OutlineObject } from '../data/interfaces/interfaces';
+import { disemvowelWord } from './disemvowel';
 
 export const prettify = (outlineNames: string[]): string => {
 	return outlineNames.toString().replace(/,/g, ' / ');
 };
 
 export const sortOutlinesAlphabetically = (outlinesArray: OutlineObject[]): OutlineObject[] => {
-	outlinesArray.sort((a, b) => {
-		const outlineLabelA = a.letterGroupings
-			? a.letterGroupings[0].toUpperCase()
-			: a.specialOutlineMeanings[0].toUpperCase();
-		const outlineLabelB = b.letterGroupings
-			? b.letterGroupings[0].toUpperCase()
-			: b.specialOutlineMeanings[0].toUpperCase();
+	outlinesArray.sort((outlineA, outlineB) => {
+		const outlineLabelA = outlineA.letterGroupings
+			? outlineA.letterGroupings[0].toUpperCase()
+			: outlineA.specialOutlineMeanings[0].toUpperCase();
+		const outlineLabelB = outlineB.letterGroupings
+			? outlineB.letterGroupings[0].toUpperCase()
+			: outlineB.specialOutlineMeanings[0].toUpperCase();
 		return outlineLabelA < outlineLabelB ? -1 : outlineLabelA > outlineLabelB ? 1 : 0;
 	});
 	return outlinesArray;
@@ -29,29 +30,13 @@ export const randomIntFromInterval = (min: number, max: number) => {
 	return Math.floor(Math.random() * (max - min + 1) + min);
 };
 
-export const findMatchingSpecialOutline = (
-	outlineName: string,
-	outlineArray: OutlineObject[]
-): OutlineObject => {
-	const foundOutline = outlineArray.find(
-		(outline) =>
-			outline.specialOutlineMeanings && outline.specialOutlineMeanings.includes(outlineName)
-	);
-
-	// if (foundOutline === undefined)
-	// 	console.log(`Special outline for '${outlineName}' could not be found.`);
-
-	return foundOutline;
-};
-
 export const findMatchingOutline = (word: string, outlinesArray: OutlineObject[]) => {
 	const disemvoweledWord = disemvowelWord(word);
-	const matchingLetterSequenceOutline = outlinesArray
-		.filter((outline) => outline.letterGroupings)
-		.find((outline) => outline.letterGroupings.includes(disemvoweledWord));
-	const matchingSpecialOutline = findMatchingSpecialOutline(
-		word,
-		outlinesArray.filter((outline) => outline.specialOutlineMeanings)
+	const matchingLetterSequenceOutline = outlinesArray.find(
+		(outline) => outline.letterGroupings && outline.letterGroupings.includes(disemvoweledWord)
+	);
+	const matchingSpecialOutline = outlinesArray.find(
+		(outline) => outline.specialOutlineMeanings && outline.specialOutlineMeanings.includes(word)
 	);
 
 	if (matchingSpecialOutline) return matchingSpecialOutline;
@@ -59,52 +44,11 @@ export const findMatchingOutline = (word: string, outlinesArray: OutlineObject[]
 	else return null;
 };
 
-export const disemvowelWord = (word: string) => {
-	const isVowel = (letter: string) => {
-		return ['a', 'e', 'i', 'o', 'u'].indexOf(letter.toLowerCase()) !== -1;
-	};
-
-	const firstLetter = word.charAt(0);
-	const finalLetter = word.charAt(word.length - 1);
-	const wordNoVowelsOrDoubles = word
-		.replace('bb', 'b')
-		.replace('dd', 'd')
-		.replace('ff', 'f')
-		.replace('gg', 'g')
-		.replace('ll', 'l')
-		.replace('mm', 'm')
-		.replace('nn', 'n')
-		.replace('pp', 'p')
-		.replace('rr', 'r')
-		.replace('ss', 's')
-		.replace('tt', 't')
-		.replace('vv', 'v')
-		.replace('ck', 'c')
-		.replace(/[aeiou]/gi, '');
-	if (word.length === 1) return word;
-	else if (
-		isVowel(firstLetter) &&
-		(finalLetter === 'o' || finalLetter === 'a' || finalLetter === 'i')
-	)
-		return firstLetter + wordNoVowelsOrDoubles + finalLetter;
-	else if (
-		!isVowel(firstLetter) &&
-		(finalLetter === 'o' || finalLetter === 'a' || finalLetter === 'i')
-	)
-		return wordNoVowelsOrDoubles + finalLetter;
-	else if (isVowel(firstLetter)) return firstLetter + wordNoVowelsOrDoubles;
-	else return wordNoVowelsOrDoubles;
+export const outlineMatchesSearchTerm = (outline: OutlineObject, searchTerm: string) => {
+	return (
+		(outline.specialOutlineMeanings &&
+			outline.specialOutlineMeanings.join('').includes(searchTerm)) ||
+		(outline.letterGroupings && outline.letterGroupings.join('').includes(searchTerm)) ||
+		(outline.letterGroupings && outline.letterGroupings.includes(disemvowelWord(searchTerm)))
+	);
 };
-
-export const disemvowelBodyOfText = (text: string) => {
-	const stringArray = text.split(' ');
-	const disemvoweledStringArray = stringArray.map((word) => disemvowelWord(word));
-	const disemvoweledText = disemvoweledStringArray.join(' ');
-	return disemvoweledText;
-};
-
-const testSentence =
-	'All men live enveloped in whale-lines. All are born with halters round their necks; but it is only when caught in the swift, sudden turn of death, that mortals realize the silent, subtle, everpresent perils of life.';
-
-// console.log(testSentence);
-// console.log(disemvowelBodyOfText(testSentence));


### PR DESCRIPTION
Tidying up code, removing duplication and needless complexity. This follows up on work done in https://github.com/frederickobrien/teeline-online/pull/41, making the groupings/special meanings work much more smoothly with each other, and addresses some UI kinks.

Changes include:

- Trimming search terms so results don't vanish when there are spaces after the word
- Deleting duplicate disemvowelment scripts... not sure how that happened in the first place
- Address a visual mistake where revision flash cards looked slightly different depending on which side was toggled to show first
- Clearer variable names and cleaner if/else checks where possible

In a similar spirit it would be nice to settle on what to do with all the SVG files that currently live in the public directory. They're not necessary to the website - just stepping stones on the way to adding outline objects to the core dataset - but feel like a nice thing to have available in the repository. Maybe something to break out into a separate project, rejigging teeline-online as a monorepo.