### PR TITLE
Fix Prettier CLI scripts

### DIFF
--- a/website/.prettierrc
+++ b/website/.prettierrc
@@ -2,5 +2,6 @@
 	"useTabs": true,
 	"singleQuote": true,
 	"trailingComma": "none",
-	"printWidth": 100
+	"printWidth": 100,
+	"plugins": ["prettier-plugin-svelte"]
 }

--- a/website/package.json
+++ b/website/package.json
@@ -7,8 +7,8 @@
 		"preview": "npm run copy-data && vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch",
-		"lint": "prettier --plugin-search-dir . --check .",
-		"format": "prettier --plugin-search-dir . --write .",
+		"lint": "prettier --check  --plugin prettier-plugin-svelte .",
+		"format": "prettier --write --plugin prettier-plugin-svelte .",
 		"copy-data": "mkdir static/data && cp src/data/outlines.json static/data/outlines.json"
 	},
 	"devDependencies": {

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -39,7 +39,9 @@
 		font-weight: 500;
 		font-display: swap;
 		src: url('/fonts/handwriting.otf'); /* IE9 Compat Modes */
-		src: local(''), url('/fonts/handwriting.otf') format('embedded-opentype'),
+		src:
+			local(''),
+			url('/fonts/handwriting.otf') format('embedded-opentype'),
 			/* IE6-IE8 */ url('/fonts/handwriting.otf') format('woff2'),
 			/* Super Modern Browsers */ url('/fonts/handwriting.otf') format('woff'),
 			/* Modern Browsers */ url('/fonts/handwriting.otf') format('truetype'),


### PR DESCRIPTION
God knows how long this was happening but I noticed Prettier wasn't working as intended when running locally:

![image](https://github.com/frederickobrien/teeline-online/assets/11380557/e4fe9b6f-4a50-4f87-a447-64aa64c44d73)

I used the https://github.com/sveltejs/prettier-plugin-svelte documentation for reference to update the scripts and all seems well.