### PR TITLE
Add basic error page

### DIFF
--- a/website/src/routes/+error.svelte
+++ b/website/src/routes/+error.svelte
@@ -1,0 +1,18 @@
+<svelte:head>
+	<title>Error | teeline.online</title>
+</svelte:head>
+
+<div class="error-content-container">
+	<h1>404</h1>
+	<p>
+		Oh dear. This page doesn't exist, and probably never did. Let's get you <a href="/">home</a> before
+		you hurt yourself.
+	</p>
+</div>
+
+<style>
+	.error-content-container {
+		text-align: center;
+		margin-top: 5rem;
+	}
+</style>


### PR DESCRIPTION
This adds a super simple error page to replace the one thrown up by Netlify when a page can't be found.

Where once there was this...

![image](https://github.com/frederickobrien/teeline-online/assets/11380557/fd3e768e-c5b8-44cd-bfc7-c10b3bae2f28)

... there will now be this...

![image](https://github.com/frederickobrien/teeline-online/assets/11380557/b1d3df24-2bde-4666-8fef-4aaad3ae05a4)

Not much to look at but at least it's consistent with the site's look and feel.