### PR TITLE
Make line outline animation delays relative to previous line length and animation speed

### DIFF
--- a/website/src/data/interfaces/interfaces.ts
+++ b/website/src/data/interfaces/interfaces.ts
@@ -4,7 +4,7 @@ export type OutlineObject = {
 	lines: LineDetails[];
 };
 
-type LineDetails = {
+export type LineDetails = {
 	path: string;
 	translateValues: number[];
 };

--- a/website/src/lib/cards/OutlineCardAnimated.svelte
+++ b/website/src/lib/cards/OutlineCardAnimated.svelte
@@ -6,6 +6,8 @@
 	export let outlineObject: OutlineObject;
 	export let displayName = true;
 
+	let animationSpeedInSecs = 1;
+
 	const makeLetterLabel = (letterGroupings: string[]) => {
 		if (letterGroupings.length === 1 && letterGroupings[0].length === 1) {
 			return `Letter`;
@@ -15,9 +17,9 @@
 	};
 </script>
 
-<div class="outline-container">
+<div class="outline-container" style="--speed: {animationSpeedInSecs}s">
 	<div class="outline-content">
-		<OutlineSvg {outlineObject} class="path" />
+		<OutlineSvg {outlineObject} {animationSpeedInSecs} class="path" />
 		{#if displayName && outlineObject.letterGroupings.length > 0}
 			<div class="outline-label">
 				{makeLetterLabel(outlineObject.letterGroupings)}
@@ -49,7 +51,7 @@
 	.outline-container:hover :global(.path) {
 		stroke-dasharray: 1000;
 		stroke-dashoffset: 1000;
-		animation: dash 2s linear forwards;
+		animation: dash var(--speed) linear forwards;
 	}
 
 	.outline-label {

--- a/website/src/lib/cards/OutlineSVG.svelte
+++ b/website/src/lib/cards/OutlineSVG.svelte
@@ -1,12 +1,28 @@
 <script lang="ts">
-	import type { OutlineObject } from '../../data/interfaces/interfaces';
+	import type { LineDetails, OutlineObject } from '../../data/interfaces/interfaces';
 	export let outlineObject: OutlineObject;
 	import { prettify } from '../../scripts/helpers';
 
-	let outlineName =
+	const outlineName =
 		outlineObject.specialOutlineMeanings.length > 0
 			? prettify(outlineObject.specialOutlineMeanings)
 			: prettify(outlineObject.letterGroupings);
+
+	const inferPathLength = (pathString: string) => {
+		const svgPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+		svgPath.setAttribute('d', pathString);
+		return Math.floor(svgPath.getTotalLength());
+	};
+
+	const inferAnimationDelay = (lineIndex: number, lineDetailsArray: LineDetails[]) => {
+		if (lineIndex === 0) return 0;
+		const precedingLines = lineDetailsArray.slice(0, lineIndex);
+		const precedingLinesCombinedLength = precedingLines
+			.map((line) => inferPathLength(line.path))
+			.reduce((a, b) => a + b, 0);
+		const delayInSeconds = precedingLinesCombinedLength / 500;
+		return delayInSeconds;
+	};
 </script>
 
 <svg
@@ -37,7 +53,7 @@
 			stroke-width="10"
 			stroke-linecap="round"
 			stroke-linejoin="round"
-			style="animation-delay: {i}s"
+			style="animation-delay: {inferAnimationDelay(i, outlineObject.lines)}s"
 			d={line.path}
 		/>
 	{/each}

--- a/website/src/lib/cards/OutlineSVG.svelte
+++ b/website/src/lib/cards/OutlineSVG.svelte
@@ -10,24 +10,28 @@
 			? prettify(outlineObject.specialOutlineMeanings)
 			: prettify(outlineObject.letterGroupings);
 
-	const inferPathLength = (pathString: string) => {
-		const svgPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-		svgPath.setAttribute('d', pathString);
-		return Math.floor(svgPath.getTotalLength());
-	};
-
 	const inferAnimationDelay = (
 		lineIndex: number,
 		lineDetailsArray: LineDetails[],
 		animationSpeed: number
 	) => {
 		if (lineIndex === 0) return 0;
-		const precedingLines = lineDetailsArray.slice(0, lineIndex);
-		const precedingLinesCombinedLength = precedingLines
-			.map((line) => inferPathLength(line.path))
-			.reduce((a, b) => a + b, 0);
-		const delayInSeconds = (precedingLinesCombinedLength / 900) * animationSpeed;
-		return delayInSeconds;
+		// Nasty hack to get around SSR
+		else if (typeof document === 'undefined') return 1;
+		else {
+			const inferPathLength = (pathString: string) => {
+				const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+				path.setAttribute('d', pathString);
+				return path.getTotalLength();
+			};
+
+			const precedingLines = lineDetailsArray.slice(0, lineIndex);
+			const precedingLinesCombinedLength = precedingLines
+				.map((line) => inferPathLength(line.path))
+				.reduce((a, b) => a + b, 0);
+			const delayInSeconds = (precedingLinesCombinedLength / 900) * animationSpeed;
+			return delayInSeconds;
+		}
 	};
 </script>
 

--- a/website/src/lib/cards/OutlineSVG.svelte
+++ b/website/src/lib/cards/OutlineSVG.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-	import type { LineDetails, OutlineObject } from '../../data/interfaces/interfaces';
 	export let outlineObject: OutlineObject;
+	export let animationSpeedInSecs: number = 1;
+
+	import type { LineDetails, OutlineObject } from '../../data/interfaces/interfaces';
 	import { prettify } from '../../scripts/helpers';
 
 	const outlineName =
@@ -14,13 +16,17 @@
 		return Math.floor(svgPath.getTotalLength());
 	};
 
-	const inferAnimationDelay = (lineIndex: number, lineDetailsArray: LineDetails[]) => {
+	const inferAnimationDelay = (
+		lineIndex: number,
+		lineDetailsArray: LineDetails[],
+		animationSpeed: number
+	) => {
 		if (lineIndex === 0) return 0;
 		const precedingLines = lineDetailsArray.slice(0, lineIndex);
 		const precedingLinesCombinedLength = precedingLines
 			.map((line) => inferPathLength(line.path))
 			.reduce((a, b) => a + b, 0);
-		const delayInSeconds = precedingLinesCombinedLength / 500;
+		const delayInSeconds = (precedingLinesCombinedLength / 900) * animationSpeed;
 		return delayInSeconds;
 	};
 </script>
@@ -53,7 +59,7 @@
 			stroke-width="10"
 			stroke-linecap="round"
 			stroke-linejoin="round"
-			style="animation-delay: {inferAnimationDelay(i, outlineObject.lines)}s"
+			style="animation-delay: {inferAnimationDelay(i, outlineObject.lines, animationSpeedInSecs)}s"
 			d={line.path}
 		/>
 	{/each}


### PR DESCRIPTION
Inspired (and mostly worked out in https://svelte.dev/repl/b70938d563c443ccaedbb9f3b1feca64?version=4.2.2) by @mxdvl, this PR adjusts the logic that animates outlines. Before there was a blanket one second delay between lines being drawn - sometimes leading to unnatural looking flows - now it's depends on the length of the previous line and the animation speed. 

This is done in `OutlineSVG.svelte` when the paths of a given outline are being iterated over. There's a little bit of nasty element creation going on - not as clean as the proof of concept Max put together - but it was the best solution I could come up with within the confines of a Svelte each loop. Perhaps scope for [jsdom](https://www.npmjs.com/package/jsdom) or some such to step in further down the line but it seems to work ok with this solution.

The animation speed adjustment has no visible impact for now but seemed sensible to include as a 'wpm' toggle of some kind (allowing users to see what 60, 80, 100, 120 wpm looks like) would be super cool, especially if the site ever starts animating entire sentences or passages.