### PR TITLE
Stop search being case sensitive

### DIFF
--- a/website/src/routes/outlines/+page.svelte
+++ b/website/src/routes/outlines/+page.svelte
@@ -6,8 +6,8 @@
 	import { outlineMatchesSearchTerm, sortOutlinesAlphabetically } from '../../scripts/helpers';
 
 	let displayedOutlines: OutlineObject[] = allOutlines;
-	let alphabetToggleOn = false;
-	let searchTerm = null;
+	let alphabetToggleOn: boolean = false;
+	let searchTerm: string = '';
 
 	const alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
 
@@ -18,7 +18,7 @@
 	const toggleAlphabetFilter = () => {
 		displayedOutlines = alphabetToggleOn ? allOutlines : alphabetOutlines;
 		alphabetToggleOn = !alphabetToggleOn;
-		searchTerm = null;
+		searchTerm = '';
 	};
 
 	const filterOutlines = (outlines: OutlineObject[], searchTerm: string) => {
@@ -42,7 +42,7 @@
 		bind:value={searchTerm}
 		on:input={() => {
 			const outlinesToFilter = alphabetToggleOn ? alphabetOutlines : allOutlines;
-			filterOutlines(outlinesToFilter, searchTerm.trim());
+			filterOutlines(outlinesToFilter, searchTerm.trim().toLowerCase());
 		}}
 	/>
 </div>


### PR DESCRIPTION
This PR addresses issue #138 by converting all search terms into lower case before searching for matching outlines. Before you wouldn't find a match if the search term was the same but the casing was different, which was rubbish. 

### Before

![image](https://github.com/frederickobrien/teeline-online/assets/11380557/babfbe0b-fa99-477f-9dbf-16e70433b729)

### After

![image](https://github.com/frederickobrien/teeline-online/assets/11380557/fee82e82-b8be-49bb-b669-581748f648c5)

It also adjusts the type of `searchTerm` to always be string - an empty string is fine as a default value rather than the `null` that was there before.