### PR TITLE
Handle existing directory in `copy-data`

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch",
 		"lint": "prettier --check  --plugin prettier-plugin-svelte .",
 		"format": "prettier --write --plugin prettier-plugin-svelte .",
-		"copy-data": "mkdir static/data && cp src/data/outlines.json static/data/outlines.json"
+		"copy-data": "mkdir -p static/data && cp src/data/outlines.json static/data/outlines.json"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-netlify": "^2.0.8",


### PR DESCRIPTION
## What does this change?

Add the `-p` flag to `copy-data`’s `mkdir` command.

## Why?

[`mkdir`’s `-p` flag](https://www.gnu.org/software/coreutils/manual/html_node/mkdir-invocation.html#index-_002dp-5) ensures parents are created, but also ensures that creating the folder repeatedly is idempotent.

This prevents error on subsequent `npm run dev` invocations.