### PR TITLE
Refactor line drawing to smooth it out

### DIFF
--- a/website/src/lib/cards/OutlineCardAnimated.svelte
+++ b/website/src/lib/cards/OutlineCardAnimated.svelte
@@ -6,7 +6,7 @@
 	export let outlineObject: OutlineObject;
 	export let displayName = true;
 
-	let animationSpeedInSecs = 1;
+	let drawingSpeed = 900;
 
 	const makeLetterLabel = (letterGroupings: string[]) => {
 		if (letterGroupings.length === 1 && letterGroupings[0].length === 1) {
@@ -17,9 +17,9 @@
 	};
 </script>
 
-<div class="outline-container" style="--speed: {animationSpeedInSecs}s">
+<div class="outline-container">
 	<div class="outline-content">
-		<OutlineSvg {outlineObject} {animationSpeedInSecs} class="path" />
+		<OutlineSvg {outlineObject} {drawingSpeed} />
 		{#if displayName && outlineObject.letterGroupings.length > 0}
 			<div class="outline-label">
 				{makeLetterLabel(outlineObject.letterGroupings)}
@@ -48,12 +48,6 @@
 		margin: 0 auto;
 	}
 
-	.outline-container:hover :global(.path) {
-		stroke-dasharray: 1000;
-		stroke-dashoffset: 1000;
-		animation: dash var(--speed) linear forwards;
-	}
-
 	.outline-label {
 		text-align: center;
 		font-size: 1.2rem;
@@ -70,14 +64,5 @@
 
 	.outline-content {
 		padding: 20px;
-	}
-
-	@keyframes dash {
-		from {
-			stroke-dashoffset: 1100;
-		}
-		to {
-			stroke-dashoffset: 0;
-		}
 	}
 </style>


### PR DESCRIPTION
## What does this change?

Unifies SVG styles and logic to leaf component, `OutlineSVG.svelte`, which now receives a speed that will be consistent across all drawn teelines.

Removed unused and redundant SVG attributes.

Building on top of #145

## Why?

Enables smoother line animations and prepares the ground for much swankier animations where the pen tip is highlighted with a dot, as in https://github.com/mxdvl/teeline-online/pull/1