### PR TITLE
Draw pen location

### DIFF
--- a/website/src/lib/cards/OutlineSVG.svelte
+++ b/website/src/lib/cards/OutlineSVG.svelte
@@ -83,7 +83,8 @@
 	:global(.outline-container:hover) :is(.path, .dot) {
 		animation-name: dash;
 		animation-duration: calc(1s * var(--length) / var(--speed));
-		animation-timing-function: ease-out;
+		/* This is trying to mimic a hand movement… https://cubic-bezier.com/#.12,0,.84,1 */
+		animation-timing-function: cubic-bezier(0.12, 0, 0.84, 1);
 		animation-delay: var(--delay);
 		animation-iteration-count: 1;
 		animation-fill-mode: both;

--- a/website/src/lib/cards/OutlineSVG.svelte
+++ b/website/src/lib/cards/OutlineSVG.svelte
@@ -44,7 +44,7 @@
 	<path class="line" d="M 80 460 H 650" />
 	{#each outlineObject.lines as line, i}
 		{@const length = Math.ceil(SVGPathCommander.getTotalLength(line.path))}
-		<path
+		<g
 			style={Object.entries({
 				length,
 				speed: drawingSpeed,
@@ -53,10 +53,10 @@
 				.map(([key, value]) => `--${key}: ${value}`)
 				.join(';')}
 			transform="translate({line.translateValues})"
-			class="path"
-			stroke-dasharray={length}
-			d={line.path}
-		/>
+		>
+			<path class="dot" stroke-dasharray="0 {1 + length}" d={line.path} />
+			<path class="path" stroke-dasharray={length} d={line.path} />
+		</g>
 	{/each}
 </svg>
 
@@ -79,16 +79,23 @@
 	.path {
 		stroke-width: 10;
 		stroke: currentColor;
-		stroke-dasharray: var(--length);
 	}
-
-	:global(.outline-container:hover) .path {
+	:global(.outline-container:hover) :is(.path, .dot) {
 		animation-name: dash;
 		animation-duration: calc(1s * var(--length) / var(--speed));
 		animation-timing-function: ease-out;
 		animation-delay: var(--delay);
 		animation-iteration-count: 1;
 		animation-fill-mode: both;
+	}
+
+	.dot {
+		stroke: lightgrey;
+		stroke-width: 96;
+		stroke-opacity: 0.6;
+		stroke-dashoffset: 1;
+		animation-fill-mode: none !important;
+		mix-blend-mode: multiply;
 	}
 
 	@keyframes dash {

--- a/website/src/lib/cards/OutlineSVG.svelte
+++ b/website/src/lib/cards/OutlineSVG.svelte
@@ -65,6 +65,10 @@
 		width: 100%;
 	}
 
+	g {
+		mix-blend-mode: multiply;
+	}
+
 	path {
 		stroke-linecap: round;
 		stroke-linejoin: round;
@@ -93,10 +97,8 @@
 	.dot {
 		stroke: lightgrey;
 		stroke-width: 96;
-		stroke-opacity: 0.6;
 		stroke-dashoffset: 1;
 		animation-fill-mode: none !important;
-		mix-blend-mode: multiply;
 	}
 
 	@keyframes dash {


### PR DESCRIPTION
## What does this change

Add the pen location behind the top of the line being drawn on hover.

Follow-up on #148 

## Why

Making it easier to follow the line as it it being drawn.



<img src="https://github.com/frederickobrien/teeline-online/assets/76776/8f0469ad-e237-4d66-bf4e-2614365afc4a" width="200" alt="screen capture showing a path being drawn" >
