### PR TITLE
Display exact matches at top of search results

### DIFF
--- a/website/src/routes/outlines/+page.svelte
+++ b/website/src/routes/outlines/+page.svelte
@@ -3,9 +3,10 @@
 	import OutlineCardAnimated from '$lib/cards/OutlineCardAnimated.svelte';
 	import Toggle from '../../lib/toggle.svelte';
 	import allOutlines from '../../data/outlines.json';
-	import { outlineMatchesSearchTerm, sortOutlinesAlphabetically } from '../../scripts/helpers';
+	import { sortOutlinesAlphabetically } from '../../scripts/helpers';
+	import { filterAndSortOutlines } from '../../scripts/search';
 
-	let displayedOutlines: OutlineObject[] = allOutlines;
+	let displayedOutlines: OutlineObject[] = sortOutlinesAlphabetically(allOutlines);
 	let alphabetToggleOn: boolean = false;
 	let searchTerm: string = '';
 
@@ -19,10 +20,6 @@
 		displayedOutlines = alphabetToggleOn ? allOutlines : alphabetOutlines;
 		alphabetToggleOn = !alphabetToggleOn;
 		searchTerm = '';
-	};
-
-	const filterOutlines = (outlines: OutlineObject[], searchTerm: string) => {
-		displayedOutlines = outlines.filter((outline) => outlineMatchesSearchTerm(outline, searchTerm));
 	};
 </script>
 
@@ -42,13 +39,13 @@
 		bind:value={searchTerm}
 		on:input={() => {
 			const outlinesToFilter = alphabetToggleOn ? alphabetOutlines : allOutlines;
-			filterOutlines(outlinesToFilter, searchTerm.trim().toLowerCase());
+			displayedOutlines = filterAndSortOutlines(outlinesToFilter, searchTerm.trim().toLowerCase());
 		}}
 	/>
 </div>
 
 <div class="animated-container">
-	{#each sortOutlinesAlphabetically(displayedOutlines) as outlineObject}
+	{#each displayedOutlines as outlineObject}
 		<OutlineCardAnimated {outlineObject} />
 	{/each}
 </div>

--- a/website/src/scripts/helpers.ts
+++ b/website/src/scripts/helpers.ts
@@ -45,11 +45,3 @@ export const findMatchingOutline = (word: string, outlinesArray: OutlineObject[]
 	else if (matchingLetterSequenceOutline) return matchingLetterSequenceOutline;
 	else return null;
 };
-
-export const outlineMatchesSearchTerm = (outline: OutlineObject, searchTerm: string) => {
-	return (
-		outline.specialOutlineMeanings.join('').includes(searchTerm) ||
-		outline.letterGroupings.join('').includes(searchTerm) ||
-		outline.letterGroupings.includes(disemvowelWord(searchTerm))
-	);
-};

--- a/website/src/scripts/search.ts
+++ b/website/src/scripts/search.ts
@@ -1,0 +1,35 @@
+import type { OutlineObject } from '../data/interfaces/interfaces';
+import { disemvowelWord } from './disemvowel';
+
+export const filterAndSortOutlines = (outlines: OutlineObject[], searchTerm: string) => {
+	const filteredOutlines = outlines.filter((outline) =>
+		outlineMatchesSearchTerm(outline, searchTerm)
+	);
+	return sortOutlinesByClosenessToSearchTerm(filteredOutlines, searchTerm);
+};
+
+const outlineMatchesSearchTerm = (outline: OutlineObject, searchTerm: string) => {
+	return (
+		outline.specialOutlineMeanings.join('').includes(searchTerm) ||
+		outline.letterGroupings.join('').includes(disemvowelWord(searchTerm))
+	);
+};
+
+const sortOutlinesByClosenessToSearchTerm = (outlines: OutlineObject[], searchTerm: string) => {
+	const giveOutlineMatchScore = (outline: OutlineObject, searchTerm: string) => {
+		const hasExactSpecialMatch = outline.specialOutlineMeanings.some(
+			(specialOutline) => specialOutline === searchTerm
+		);
+		const hasExactLetterGroupingMatch = outline.letterGroupings.some(
+			(letterGrouping) => letterGrouping === disemvowelWord(searchTerm)
+		);
+		if (hasExactSpecialMatch && hasExactLetterGroupingMatch) return 3;
+		else if (hasExactSpecialMatch || hasExactLetterGroupingMatch) return 2;
+		else return 1;
+	};
+	return outlines.sort((outlineA, outlineB) => {
+		const outlineAScore = giveOutlineMatchScore(outlineA, searchTerm);
+		const outlineBScore = giveOutlineMatchScore(outlineB, searchTerm);
+		return outlineAScore > outlineBScore ? -1 : outlineAScore < outlineBScore ? 1 : 0;
+	});
+};


### PR DESCRIPTION
This PR attempts to make the search functionality a little smarter by displaying exact matches to search terms (be they special outline or groupings) first.

The result looks like this:

![image](https://github.com/frederickobrien/teeline-online/assets/11380557/32a471cf-3171-468a-be20-5a8041d0946a)

Before the 'the' card was down on the third line. Not very helpful. 