### PR TITLE
Fix animation bug

### DIFF
--- a/website/src/routes/outlines/+page.svelte
+++ b/website/src/routes/outlines/+page.svelte
@@ -45,9 +45,11 @@
 </div>
 
 <div class="animated-container">
-	{#each displayedOutlines as outlineObject}
-		<OutlineCardAnimated {outlineObject} />
-	{/each}
+	{#key displayedOutlines}
+		{#each displayedOutlines as outlineObject}
+			<OutlineCardAnimated {outlineObject} />
+		{/each}
+	{/key}
 </div>
 
 {#if displayedOutlines.length === 0}


### PR DESCRIPTION
This _seems_ to address a funky issue I came across where animated outline cards would start appearing mid-flow once you start using the search bar on the outlines page:

![image](https://github.com/frederickobrien/teeline-online/assets/11380557/8a660beb-4c2d-41fe-a000-fe4c71d2bd7b)

Not ideal. I've wrapped the animated cards in a [Svelte key block](https://svelte.dev/docs/logic-blocks) (the same fix for #147) so that they're destroyed and recreated every time the `displayedOutlines` value changes. The results look like what we want.

![image](https://github.com/frederickobrien/teeline-online/assets/11380557/6653e02d-cf1b-4466-929a-5b99dd87bff8)

Very possible I'm treating the symptom rather than the cause here but I wanted to get a fix live and this seems to do the trick.