### PR TITLE
Render letter grouping if it exists (rather than generating it)

### DIFF
--- a/website/src/scripts/build-outline-objects.ts
+++ b/website/src/scripts/build-outline-objects.ts
@@ -18,8 +18,14 @@ const createOutlineObject = (word: string): OutlineObject => {
 	const specialOutline = allOutlines.find((outline) =>
 		outline.specialOutlineMeanings.includes(word)
 	);
+	const letterGrouping = allOutlines.find((outline) =>
+		outline.letterGroupings.includes(disemvowelWord(word))
+	);
 	if (specialOutline) {
 		return specialOutline;
+	}
+	if (letterGrouping) {
+		return letterGrouping;
 	}
 	// Remove special characters from word
 	const cleanedWord = disemvowelWord(word).replace(/[^a-zA-Z]/g, '');


### PR DESCRIPTION
Adjustment to outline building logic that defers to a custom letter grouping (such as 'pb' or 'wr') is it exists rather than generating one from scratch. The results will be better and creates space for #211 to be as useful as possible when done.