### PR TITLE
Disemvoweler better handles multi-vowel word endings

### DIFF
--- a/website/src/scripts/disemvowel.test.ts
+++ b/website/src/scripts/disemvowel.test.ts
@@ -5,6 +5,9 @@ test('testing word disemvowelment', () => {
 	expect(disemvowelWord('bellow')).toBe('blw');
 	expect(disemvowelWord('hello')).toBe('hlo');
 	expect(disemvowelWord('amusement')).toBe('amsmnt');
+	expect(disemvowelWord('tee')).toBe('te');
+	expect(disemvowelWord('pie')).toBe('pi');
+	expect(disemvowelWord('undue')).toBe('undu');
 });
 
 test('testing passage disemvowelment', () => {

--- a/website/src/scripts/disemvowel.ts
+++ b/website/src/scripts/disemvowel.ts
@@ -1,11 +1,12 @@
 export const disemvowelWord = (word: string) => {
+	if (word.length === 1) return word;
+
+	const firstLetter = word.slice(0, 1);
 	const isVowel = (letter: string) => {
 		return ['a', 'e', 'i', 'o', 'u'].includes(letter.toLowerCase());
 	};
-	const firstLetter = word.charAt(0);
-	const finalLetter = word.charAt(word.length - 1);
-	const finalLetterIsSoundedVowel = ['a', 'i', 'o', 'u'].includes(finalLetter.toLowerCase());
-	const endsWithUe = word.slice(-2) === 'ue';
+	const start = isVowel(firstLetter) ? firstLetter : '';
+
 	const wordNoVowelsOrDoubles = word
 		.replace('bb', 'b')
 		.replace('cc', 'c')
@@ -25,15 +26,31 @@ export const disemvowelWord = (word: string) => {
 		.replace('ck', 'c')
 		.replace('ght', 't')
 		.replace(/[aeiou]/gi, '');
-	if (word.length === 1) return word;
-	else if (isVowel(firstLetter) && finalLetterIsSoundedVowel)
-		return firstLetter + wordNoVowelsOrDoubles + finalLetter;
-	else if (!isVowel(firstLetter) && finalLetterIsSoundedVowel)
-		return wordNoVowelsOrDoubles + finalLetter;
-	else if (isVowel(firstLetter) && endsWithUe) return firstLetter + wordNoVowelsOrDoubles + 'u';
-	else if (!isVowel(firstLetter) && endsWithUe) return wordNoVowelsOrDoubles + 'u';
-	else if (isVowel(firstLetter)) return firstLetter + wordNoVowelsOrDoubles;
-	else return wordNoVowelsOrDoubles;
+
+	const inferEnd = (word: string) => {
+		const lastLetter = word.slice(-1);
+		const lastTwoLetters = word.slice(-2);
+		const finalLetterIsSoundedVowel = ['a', 'i', 'o', 'u'].includes(lastLetter.toLowerCase());
+		if (finalLetterIsSoundedVowel) return lastLetter;
+		else
+			switch (lastTwoLetters) {
+				case 'ue':
+					return 'u';
+				case 'ee':
+					return 'e';
+				case 'ae':
+					return 'i';
+				case 'ie':
+					return 'i';
+				case 'oe':
+					return 'o';
+				default:
+					return '';
+			}
+	};
+	const end = inferEnd(word);
+
+	return start + wordNoVowelsOrDoubles + end;
 };
 
 export const disemvowelBodyOfText = (text: string) => {


### PR DESCRIPTION
This improves the `disemvowel` script while also doing a bit of refactoring. Words with multi-vowel endings are now handled better than before. With the old logic words like 'tee' were slipping through the net because the last two letters are silent on their own but not together. 

Et voila

| Before  |  After |
|---|---|
| ![image](https://github.com/frederickobrien/teeline-online/assets/11380557/1373c964-d469-4af5-808e-7146f0e0a732) | ![image](https://github.com/frederickobrien/teeline-online/assets/11380557/4cc224a2-ac19-43b4-9b55-2832d1ef2b51) |

Far from perfect, but a little better than before.