### PR TITLE
Weave multi-word special meaning outlines into generated passages

### DIFF
--- a/website/src/lib/ShorthandPassage.svelte
+++ b/website/src/lib/ShorthandPassage.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import Container from './outlineSVGs/OutlineSVG.svelte';
 	import Lines from './outlineSVGs/Lines.svelte';
-	import { createOutlineObjects } from '../scripts/build-outline-objects';
+	import { convertPassageToOutlines } from '../scripts/build-outline-objects';
 	import OutlineDetails from './cards/OutlineDetails.svelte';
 	import type { OutlineObject } from '../data/interfaces/interfaces';
 	import { hydratedData } from '../scripts/hydrate-outline-data';
 
 	export let text: string;
-	$: outlineObjects = createOutlineObjects(text, hydratedData);
+	$: outlineObjects = convertPassageToOutlines(text, hydratedData);
 
 	const getPrecedingOutlinesLength = (outlineObjects: OutlineObject[], index: number) =>
 		outlineObjects

--- a/website/src/scripts/build-outline-objects.ts
+++ b/website/src/scripts/build-outline-objects.ts
@@ -124,7 +124,7 @@ export function convertPassageToOutlines(
 				meaning.split(' ').length > longestMatch.split(' ').length &&
 				// Check we're not splicing matches e.g. matching
 				// 'and the' special meaning with 'and there'
-				cleanedPassage.charAt(meaning.length) === ' '
+				(cleanedPassage.charAt(meaning.length) === ' ' || cleanedPassage === meaning)
 			) {
 				longestMatch = meaning;
 				matchedOutline = outline;

--- a/website/src/scripts/build-outline-objects.ts
+++ b/website/src/scripts/build-outline-objects.ts
@@ -121,9 +121,10 @@ export function convertPassageToOutlines(
 		for (const meaning of outline.specialOutlineMeanings) {
 			if (
 				cleanedPassage.startsWith(meaning) &&
-				meaning.split(' ').length > longestMatch.split(' ').length
-				// TODO: Check that the match is for complete words. 'And there are' should
-				// not be matching with the special outline 'and the'
+				meaning.split(' ').length > longestMatch.split(' ').length &&
+				// Check we're not splicing matches e.g. matching
+				// 'and the' special meaning with 'and there'
+				cleanedPassage.charAt(meaning.length) === ' '
 			) {
 				longestMatch = meaning;
 				matchedOutline = outline;

--- a/website/src/scripts/build-outline-objects.ts
+++ b/website/src/scripts/build-outline-objects.ts
@@ -33,7 +33,7 @@ export const findOrCreateOutlineObject = (
 	// Find matching letter or letter grouping at start of word until no more letters
 	function mapWordToOutlines(
 		word: string,
-		outlines: OutlineObject[],
+		lettersAndGroupings: OutlineObject[],
 		wordOutlines: OutlineObject[] = []
 	): OutlineObject[] {
 		if (!word) return wordOutlines; // Base case for recursion
@@ -42,7 +42,7 @@ export const findOrCreateOutlineObject = (
 		let longestMatch = '';
 		let matchedOutline: OutlineObject | undefined;
 
-		for (const outline of outlines) {
+		for (const outline of lettersAndGroupings) {
 			for (const grouping of outline.letterGroupings) {
 				if (word.startsWith(grouping) && grouping.length > longestMatch.length) {
 					longestMatch = grouping;
@@ -55,7 +55,7 @@ export const findOrCreateOutlineObject = (
 		if (!matchedOutline) return wordOutlines;
 
 		// Otherwise, append the found outline and continue recursively
-		return mapWordToOutlines(word.slice(longestMatch.length), outlines, [
+		return mapWordToOutlines(word.slice(longestMatch.length), lettersAndGroupings, [
 			...wordOutlines,
 			matchedOutline
 		]);
@@ -109,7 +109,7 @@ export const findOrCreateOutlineObject = (
 
 export function convertPassageToOutlines(
 	passage: string,
-	outlines: OutlineObject[],
+	lettersAndGroupings: OutlineObject[],
 	result: OutlineObject[] = []
 ): OutlineObject[] {
 	const cleanedPassage = passage.replace(punctuationRegex, '');
@@ -117,7 +117,7 @@ export function convertPassageToOutlines(
 	let matchedOutline: OutlineObject | undefined;
 
 	// Find the longest special meaning match
-	for (const outline of outlines) {
+	for (const outline of lettersAndGroupings) {
 		for (const meaning of outline.specialOutlineMeanings) {
 			if (
 				cleanedPassage.startsWith(meaning) &&
@@ -135,7 +135,7 @@ export function convertPassageToOutlines(
 	if (!matchedOutline) {
 		// Default to the first word if no special meaning found
 		longestMatch = cleanedPassage.split(' ')[0];
-		matchedOutline = findOrCreateOutlineObject(longestMatch, outlines);
+		matchedOutline = findOrCreateOutlineObject(longestMatch, lettersAndGroupings);
 	}
 
 	const updatedResult = [...result, matchedOutline];
@@ -143,5 +143,5 @@ export function convertPassageToOutlines(
 
 	return updatedPassage === ''
 		? updatedResult
-		: convertPassageToOutlines(updatedPassage, outlines, updatedResult);
+		: convertPassageToOutlines(updatedPassage, lettersAndGroupings, updatedResult);
 }

--- a/website/src/scripts/build-outline-objects.ts
+++ b/website/src/scripts/build-outline-objects.ts
@@ -41,7 +41,7 @@ export const findOrCreateOutlineObject = (
 		);
 		let match = word.charAt(0);
 		lettersAndGroupings.forEach((outline) =>
-			outline.letterGroupings.map((grouping) => {
+			outline.letterGroupings.forEach((grouping) => {
 				if (word.startsWith(grouping) && grouping.length > match.length) match = grouping;
 			})
 		);
@@ -101,15 +101,27 @@ export const findOrCreateOutlineObject = (
 };
 
 export const createOutlineObjects = (
-	text: string,
-	outlineObjects: OutlineObject[]
+	passage: string,
+	lettersAndGroupings: OutlineObject[],
+	result: OutlineObject[] = []
 ): OutlineObject[] => {
-	// Remove punctuation
-	text = text.replace(punctuationRegex, '');
-	// TODO: Account for multi-word special outlines
-	const wordsInText = text.toLowerCase().split(' ');
-	const createdOutlineObjects = wordsInText.map((word) =>
-		findOrCreateOutlineObject(word, outlineObjects)
+	const cleanedPassage = passage.replace(punctuationRegex, '');
+	const multiWordSpecialMatch = lettersAndGroupings.find((outline) =>
+		outline.specialOutlineMeanings.some(
+			(meaning) => cleanedPassage.startsWith(meaning) && meaning.split(' ').length > 1
+		)
 	);
-	return createdOutlineObjects;
+	let match = cleanedPassage.split(' ')[0];
+	lettersAndGroupings.forEach((outline) => {
+		outline.specialOutlineMeanings.forEach((meaning) => {
+			if (passage.startsWith(meaning) && meaning.split(' ').length > 1) match = meaning;
+		});
+	});
+	const outlineObject = multiWordSpecialMatch
+		? multiWordSpecialMatch
+		: findOrCreateOutlineObject(match, lettersAndGroupings);
+	const updatedResult = result.concat(outlineObject);
+	const updatedPassage = cleanedPassage.slice(match.length).trim();
+	if (updatedPassage === '') return updatedResult;
+	else return createOutlineObjects(updatedPassage, lettersAndGroupings, updatedResult);
 };

--- a/website/src/scripts/build-outline-objects.ts
+++ b/website/src/scripts/build-outline-objects.ts
@@ -31,30 +31,37 @@ export const findOrCreateOutlineObject = (
 	}
 
 	// Find matching letter or letter grouping at start of word until no more letters
-	const turnWordIntoOutlineObjects = (
+	function mapWordToOutlines(
 		word: string,
-		lettersAndGroupings: OutlineObject[],
+		outlines: OutlineObject[],
 		wordOutlines: OutlineObject[] = []
-	): OutlineObject[] => {
-		const multiLetterGroupingMatch = lettersAndGroupings.find((outline) =>
-			outline.letterGroupings.some((grouping) => word.startsWith(grouping) && grouping.length > 1)
-		);
-		let match = word.charAt(0);
-		lettersAndGroupings.forEach((outline) =>
-			outline.letterGroupings.forEach((grouping) => {
-				if (word.startsWith(grouping) && grouping.length > match.length) match = grouping;
-			})
-		);
-		const outlineObject = multiLetterGroupingMatch
-			? multiLetterGroupingMatch
-			: lettersAndGroupings.find((outline) => outline.letterGroupings.includes(match));
-		const updatedWordOutlines = wordOutlines.concat(outlineObject);
-		const updatedWord = word.slice(match.length);
-		if (updatedWord.length === 0) return updatedWordOutlines;
-		else return turnWordIntoOutlineObjects(updatedWord, lettersAndGroupings, updatedWordOutlines);
-	};
+	): OutlineObject[] {
+		if (!word) return wordOutlines; // Base case for recursion
 
-	const lettersObjectArray = turnWordIntoOutlineObjects(cleanedWord, outlines);
+		// Find the longest matching letter grouping at the start of the word
+		let longestMatch = '';
+		let matchedOutline: OutlineObject | undefined;
+
+		for (const outline of outlines) {
+			for (const grouping of outline.letterGroupings) {
+				if (word.startsWith(grouping) && grouping.length > longestMatch.length) {
+					longestMatch = grouping;
+					matchedOutline = outline;
+				}
+			}
+		}
+
+		// If no match was found, return the accumulated word outlines
+		if (!matchedOutline) return wordOutlines;
+
+		// Otherwise, append the found outline and continue recursively
+		return mapWordToOutlines(word.slice(longestMatch.length), outlines, [
+			...wordOutlines,
+			matchedOutline
+		]);
+	}
+
+	const lettersObjectArray = mapWordToOutlines(cleanedWord, outlines);
 
 	// we need to get the first starting point
 	const startingObject = createStartingObject(cleanedWord, lettersObjectArray);
@@ -100,28 +107,40 @@ export const findOrCreateOutlineObject = (
 	};
 };
 
-export const createOutlineObjects = (
+export function convertPassageToOutlines(
 	passage: string,
-	lettersAndGroupings: OutlineObject[],
+	outlines: OutlineObject[],
 	result: OutlineObject[] = []
-): OutlineObject[] => {
+): OutlineObject[] {
 	const cleanedPassage = passage.replace(punctuationRegex, '');
-	const multiWordSpecialMatch = lettersAndGroupings.find((outline) =>
-		outline.specialOutlineMeanings.some(
-			(meaning) => cleanedPassage.startsWith(meaning) && meaning.split(' ').length > 1
-		)
-	);
-	let match = cleanedPassage.split(' ')[0];
-	lettersAndGroupings.forEach((outline) => {
-		outline.specialOutlineMeanings.forEach((meaning) => {
-			if (passage.startsWith(meaning) && meaning.split(' ').length > 1) match = meaning;
-		});
-	});
-	const outlineObject = multiWordSpecialMatch
-		? multiWordSpecialMatch
-		: findOrCreateOutlineObject(match, lettersAndGroupings);
-	const updatedResult = result.concat(outlineObject);
-	const updatedPassage = cleanedPassage.slice(match.length).trim();
-	if (updatedPassage === '') return updatedResult;
-	else return createOutlineObjects(updatedPassage, lettersAndGroupings, updatedResult);
-};
+	let longestMatch = '';
+	let matchedOutline: OutlineObject | undefined;
+
+	// Find the longest special meaning match
+	for (const outline of outlines) {
+		for (const meaning of outline.specialOutlineMeanings) {
+			if (
+				cleanedPassage.startsWith(meaning) &&
+				meaning.split(' ').length > longestMatch.split(' ').length
+				// TODO: Check that the match is for complete words. 'And there are' should
+				// not be matching with the special outline 'and the'
+			) {
+				longestMatch = meaning;
+				matchedOutline = outline;
+			}
+		}
+	}
+
+	if (!matchedOutline) {
+		// Default to the first word if no special meaning found
+		longestMatch = cleanedPassage.split(' ')[0];
+		matchedOutline = findOrCreateOutlineObject(longestMatch, outlines);
+	}
+
+	const updatedResult = [...result, matchedOutline];
+	const updatedPassage = cleanedPassage.slice(longestMatch.length).trim();
+
+	return updatedPassage === ''
+		? updatedResult
+		: convertPassageToOutlines(updatedPassage, outlines, updatedResult);
+}


### PR DESCRIPTION
Addresses #247 and builds on #220 by matching passages with multi-word special outlines wherever possible. This makes for much better results, as seen below.

### Before 

![image](https://github.com/frederickobrien/teeline-online/assets/11380557/29831537-52b7-4a2d-ae6c-aafb1d076023)

### After

![image](https://github.com/frederickobrien/teeline-online/assets/11380557/309fda26-a89c-4dbc-b8c4-e92e0224f110)

Fuck yeah.

Each improvement surfaces other areas in need of attention (the special 'ing' ending for example) but I'm really pleased with this round of polishes.
