### PR TITLE
Fix line animation delay bug, add length inference tests

### DIFF
--- a/website/src/lib/ShorthandPassage.svelte
+++ b/website/src/lib/ShorthandPassage.svelte
@@ -3,17 +3,11 @@
 	import Lines from './outlineSVGs/Lines.svelte';
 	import { convertPassageToOutlines } from '../scripts/build-outline-objects';
 	import OutlineDetails from './cards/OutlineDetails.svelte';
-	import type { OutlineObject } from '../data/interfaces/interfaces';
 	import { hydratedData } from '../scripts/hydrate-outline-data';
+	import { inferPrecedingOutlinesLength } from '../scripts/line-length-inference';
 
 	export let text: string;
 	$: outlineObjects = convertPassageToOutlines(text, hydratedData);
-
-	const getPrecedingOutlinesLength = (outlineObjects: OutlineObject[], index: number) =>
-		outlineObjects
-			.slice(0, index)
-			.map(({ lines }) => lines.map(({ length }) => length).reduce((a, b) => a + b + 60, 0))
-			.reduce((a, b) => a + b, 0);
 </script>
 
 <div class="animation-container passage-container">
@@ -22,7 +16,7 @@
 			<Container {outlineObject} isStandalone={false} let:line let:previousLinesLength>
 				<Lines
 					{line}
-					precedingOutlinesLength={getPrecedingOutlinesLength(outlineObjects, i)}
+					precedingOutlinesLength={inferPrecedingOutlinesLength(outlineObjects, i)}
 					{previousLinesLength}
 					drawingSpeed={900}
 				/>

--- a/website/src/lib/outlineSVGs/OutlineSVG.svelte
+++ b/website/src/lib/outlineSVGs/OutlineSVG.svelte
@@ -5,22 +5,11 @@
 
 	import type { OutlineObject } from '../../data/interfaces/interfaces';
 	import { prettify } from '../../scripts/helpers';
+	import { inferPrecedingLinesLength } from '../../scripts/line-length-inference';
 
 	const width = 750;
 	const margin = 100;
 	const horizontal = 460;
-
-	/**
-	 * Typical distance between the end of the previous line and the start of the next
-	 * We could calculate this precisely from the paths, but it’s probably too much effort.
-	 */
-	const pause = 60;
-
-	const getPreviousLinesLength = (index: number) =>
-		outlineObject.lines
-			.slice(0, index)
-			.map(({ length }) => length)
-			.reduce((a, b) => a + b + pause, 0);
 
 	const outlineName =
 		outlineObject.specialOutlineMeanings.length > 0
@@ -41,7 +30,7 @@
 			{line}
 			{index}
 			{precedingOutlinesLength}
-			previousLinesLength={getPreviousLinesLength(index)}
+			previousLinesLength={inferPrecedingLinesLength(outlineObject, index)}
 		/>
 	{/each}
 </svg>

--- a/website/src/scripts/line-length-inference.test.ts
+++ b/website/src/scripts/line-length-inference.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from 'vitest';
+import { inferPrecedingLinesLength } from './line-length-inference';
+import { findOrCreateOutlineObject } from './build-outline-objects';
+import { hydratedData } from './hydrate-outline-data';
+
+test('testing preceding line length inference', () => {
+    expect(inferPrecedingLinesLength(findOrCreateOutlineObject("as a result", hydratedData), 2)).toBe(235);
+    expect(inferPrecedingLinesLength(findOrCreateOutlineObject("that the", hydratedData), 1)).toBe(428);
+});

--- a/website/src/scripts/line-length-inference.ts
+++ b/website/src/scripts/line-length-inference.ts
@@ -1,0 +1,19 @@
+import type { OutlineObject } from "../data/interfaces/interfaces";
+
+/**
+ * Typical distance between the end of the previous line and the start of the next
+ * We could calculate this precisely from the paths, but it’s probably too much effort.
+ */
+const pause = 60;
+
+export const inferPrecedingLinesLength = (outline: OutlineObject, index: number) =>
+    outline.lines
+        .slice(0, index)
+        .map(({ length }) => length)
+        .reduce((a, b) => a + b + pause, 0);
+
+export const inferPrecedingOutlinesLength = (outlineObjects: OutlineObject[], index: number) =>
+    outlineObjects
+        .slice(0, index)
+        .map(({ lines }) => lines.map(({ length }) => length).reduce((a, b) => a + b + pause, 0))
+        .reduce((a, b) => a + b, 0);


### PR DESCRIPTION
This seems to address an issue I noticed popping up from time to time on the generator page. The delay between lines being animated didn't look right at times. Look at the outline for 'motorway' below for example...

### Before

![chrome-capture-2024-3-26](https://github.com/frederickobrien/teeline-online/assets/11380557/d3346a5a-8ffc-422b-8ffe-a653903b03d5)

The animation delay is calculated by working out the combined length of all the lines before it in the passage. I've refactored the functions where this is done, moved them into their own little helper file, and added tests.

### After

![chrome-capture-2024-3-26-2](https://github.com/frederickobrien/teeline-online/assets/11380557/349819e2-d95f-4d29-864d-255b933d123f)

Much better!
