### PR TITLE
Fix header issue on mobile, general responsiveness improvements

### DIFF
--- a/website/src/lib/layout/Header.svelte
+++ b/website/src/lib/layout/Header.svelte
@@ -37,18 +37,24 @@
 		margin-bottom: 2rem;
 	}
 
-	nav {
-		font-size: 2rem;
-		font-weight: 700;
-	}
-
 	ul {
 		display: flex;
 		justify-content: center;
+		gap: 1rem;
 	}
 
 	li {
-		margin: 0 20px;
+		font-size: 1.5rem;
+		margin: 0;
 		list-style-type: none;
+		padding-left: 0;
+	}
+	@media (min-width: 768px) {
+		ul {
+			gap: 2rem;
+		}
+		li {
+			font-size: 1.8rem;
+		}
 	}
 </style>

--- a/website/src/routes/+page.svelte
+++ b/website/src/routes/+page.svelte
@@ -63,12 +63,21 @@
 		margin-top: 50px;
 		display: flex;
 		flex-wrap: wrap;
-		column-gap: 4%;
 		row-gap: 30px;
 	}
 
 	@media (min-width: 768px) {
 		.site-sections-container {
+			display: grid;
+			grid-template-columns: repeat(2, 1fr);
+			grid-template-rows: 1fr 1fr;
+			grid-column-gap: 2rem;
+		}
+	}
+
+	@media (min-width: 1024px) {
+		.site-sections-container {
+			width: 75%;
 			display: grid;
 			grid-template-columns: repeat(4, 1fr);
 			grid-template-rows: 1fr;

--- a/website/src/routes/+page.svelte
+++ b/website/src/routes/+page.svelte
@@ -67,9 +67,8 @@
 		row-gap: 30px;
 	}
 
-	@media (min-width: 1025px) {
+	@media (min-width: 768px) {
 		.site-sections-container {
-			width: 75%;
 			display: grid;
 			grid-template-columns: repeat(4, 1fr);
 			grid-template-rows: 1fr;

--- a/website/src/routes/learn/+page.svelte
+++ b/website/src/routes/learn/+page.svelte
@@ -32,15 +32,16 @@
 		justify-content: center;
 		row-gap: 1rem;
 	}
-
 	@media (min-width: 768px) {
 		.learn-menu {
-			flex-direction: row;
-			flex-wrap: wrap;
+			display: grid;
+			grid-template-columns: repeat(2, 1fr);
 			column-gap: 1rem;
 		}
-		.test {
-			width: 30%;
+	}
+	@media (min-width: 1024px) {
+		.learn-menu {
+			grid-template-columns: repeat(3, 1fr);
 		}
 	}
 </style>

--- a/website/src/routes/outlines/+page.svelte
+++ b/website/src/routes/outlines/+page.svelte
@@ -31,7 +31,6 @@
 </svelte:head>
 
 <div class="filters-container">
-	<Toggle toggleLabel={`Only show alphabet`} toggleFunction={toggleAlphabetFilter} />
 	<input
 		class="search-input"
 		placeholder="Search for outlines..."
@@ -41,6 +40,7 @@
 			displayedOutlines = filterAndSortOutlines(outlinesToFilter, searchTerm.trim().toLowerCase());
 		}}
 	/>
+	<Toggle toggleLabel={`Only show alphabet`} toggleFunction={toggleAlphabetFilter} />
 </div>
 
 {#if searchTerm.length > 0 && displayedOutlines.length > 0}
@@ -69,8 +69,10 @@
 	.filters-container {
 		margin: 0 auto 2rem auto;
 		display: flex;
-		flex-wrap: wrap;
+		flex-direction: column;
+		gap: 1rem;
 		justify-content: center;
+		align-items: center;
 	}
 	.search-subheading {
 		font-size: 1.8rem;

--- a/website/static/styles/app.css
+++ b/website/static/styles/app.css
@@ -71,7 +71,6 @@ small {
 
 .search-input {
 	padding: 10px 30px;
-	margin-left: 20px;
 	border-radius: 50px;
 }
 


### PR DESCRIPTION
Adjusts a issue with the header nav links going off-screen on smaller screens:

| Before  | After  |
|---|---|
| ![image](https://github.com/frederickobrien/teeline-online/assets/11380557/554b9843-386a-45c1-ad29-a6c0473d0a0a)  | ![image](https://github.com/frederickobrien/teeline-online/assets/11380557/14f029a7-7101-4415-9db2-58cd2e109d95)  |

Media queries keep the styling as before on larger screens.

Also took the opportunity to do a few tweaks elsewhere. Some of the CSS is a bit rough and ready - probably warrants a dedicated tidy up, but that's a problem for future me