### PR TITLE
Replace static outlines file with API endpoint

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -5,14 +5,13 @@
 		"node": ">=20.0.0"
 	},
 	"scripts": {
-		"dev": "npm run copy-data && vite dev",
-		"build": "npm run format && npm run lint && npm run copy-data && npm run test && vite build",
-		"preview": "npm run copy-data && vite preview",
+		"dev": "vite dev",
+		"build": "npm run format && npm run lint && npm run test && vite build",
+		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch",
 		"lint": "prettier --check --plugin prettier-plugin-svelte .",
 		"format": "prettier --write --plugin prettier-plugin-svelte .",
-		"copy-data": "mkdir -p static/data && cp src/data/outlines.json static/data/outlines.json",
 		"test": "vitest run",
 		"storybook": "storybook dev -p 6006",
 		"build-storybook": "storybook build"

--- a/website/src/routes/about/+page.svelte
+++ b/website/src/routes/about/+page.svelte
@@ -19,7 +19,7 @@
 			href="https://github.com/frederickobrien/teeline-online">GitHub</a
 		>
 		and the data at its core is available
-		<a href="/data/outlines.json">here</a>. The site is built with
+		<a href="/api/outlines">here</a>. The site is built with
 		<a href="https://svelte.dev/">Svelte</a>
 		and hosted on <a href="https://netlify.com/">Netlify</a>. The font is based on Fred's own
 		handwriting - a nod to the project being partly inspired by the revision flash cards he made

--- a/website/src/routes/api/outlines/+server.ts
+++ b/website/src/routes/api/outlines/+server.ts
@@ -1,0 +1,6 @@
+import { hydratedData } from '../../../scripts/hydrate-outline-data';
+import { json } from '@sveltejs/kit';
+
+export async function GET() {
+	return json(hydratedData);
+}


### PR DESCRIPTION
This replaces the manual copying of `outlines.json` to the /static folder with an API endpoint using Svelte routing. Where before users could access the raw JSON at `/data/outlines.json` now they can do so at `/api/outlines`.

Feels cleaner and opens the door to other services if there's ever a need for them. Another upside is the original, raw JSON file was being used whereas now it's the hydrated version with extra special outlines objects.